### PR TITLE
CDAR-824: Update to use dateutil.tz over zoneinfo for 3.8 compatibility

### DIFF
--- a/src/carma-streets/parse_kafka_logs.py
+++ b/src/carma-streets/parse_kafka_logs.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 import argparse
 from csv import writer
 import datetime
-from zoneinfo import ZoneInfo
+from dateutil import tz
 
 
 
@@ -92,7 +92,7 @@ def get_spat_timestamp(json_data: dict,test_year: int):
     Returns:
         int: epoch timestamp in milliseconds
     """
-    first_day_epoch = datetime.datetime(int(test_year), 1, 1, 0, 0, 0, tzinfo=ZoneInfo("America/New_York")).timestamp()*1000
+    first_day_epoch = datetime.datetime(int(test_year), 1, 1, 0, 0, 0, tzinfo=tz.gettz('America/New_York')).timestamp()*1000
     return json_data['intersections'][0]['moy']*60*1000 + json_data['intersections'][0]['time_stamp'] + first_day_epoch
 
 def parse_spat_to_csv(inputfile: Path, outputfile: Path):


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description
Update script to use datetime.tz to be python 3.8 compatible
<!--- Describe your changes in detail -->

## Related GitHub Issue

<!--- This project only accepts pull requests related to open GitHub issues or Jira Keys -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please DO NOT name partially fixed issues, instead open an issue specific to this fix -->
<!--- Please link to the issue here: -->

## Related Jira Key
CDAR-824
<!-- e.g. CAR-123 -->

## Motivation and Context
Make script python 3.8 compatible
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Local integration testing
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
