### PR TITLE
Fix `calc_post_encroachment_time` bug

### DIFF
--- a/vru_use_case_scripts/calc_post_encroachment_time
+++ b/vru_use_case_scripts/calc_post_encroachment_time
@@ -46,6 +46,9 @@ def get_encroachment_zone(vehicle_odom_df, pedestrian_odom_df):
     plt.plot(*vehicle_path.xy)
     plt.plot(*pedestrian_path.xy)
 
+    if intersect_point.is_empty:
+        return None
+
     return shapely.geometry.box(
         intersect_point.x - ENCROACHMENT_ZONE_WIDTH / 2,
         intersect_point.y - ENCROACHMENT_ZONE_WIDTH / 2,
@@ -127,16 +130,21 @@ pedestrian_odometry_df = parse_pedestrian_odometry_from_csv(
 
 encroachment_zone = get_encroachment_zone(vehicle_odometry_df, pedestrian_odometry_df)
 
-vehicle_enter_time = calc_vehicle_enter_time(vehicle_odometry_df, encroachment_zone)
-pedestrian_exit_time = calc_pedestrian_exit_time(
-    pedestrian_odometry_df, encroachment_zone
-)
+if encroachment_zone is not None:
+    vehicle_enter_time = calc_vehicle_enter_time(vehicle_odometry_df, encroachment_zone)
+    pedestrian_exit_time = calc_pedestrian_exit_time(
+        pedestrian_odometry_df, encroachment_zone
+    )
 
-shapely.plotting.plot_polygon(encroachment_zone, add_points=False)
+    shapely.plotting.plot_polygon(encroachment_zone, add_points=False)
+
+    print(f"vehicle enter time [ms]: {vehicle_enter_time}")
+    print(f"pedestrian exit time [ms]: {pedestrian_exit_time}")
+    print(
+        f"post-encroachment time (PET) [ms]: {vehicle_enter_time - pedestrian_exit_time}"
+    )
+else:
+    print("paths do not intersect")
 
 if cli_args.show_plot:
     plt.show()
-
-print(f"vehicle enter time [ms]: {vehicle_enter_time}")
-print(f"pedestrian exit time [ms]: {pedestrian_exit_time}")
-print(f"post-encroachment time (PET) [ms]: {vehicle_enter_time - pedestrian_exit_time}")


### PR DESCRIPTION
# PR Details
## Description

This PR fixes a bug that crashes the `calc_post_encroachment_time` script when the vehicle and pedestrian paths don't intersect. There is now a check for intersection.

## Related GitHub Issue

## Related Jira Key

Closes [CDAR-875](https://usdot-carma.atlassian.net/browse/CDAR-875)

## Motivation and Context

## How Has This Been Tested?

## Types of changes

- [x] Defect fix (non-breaking change that fixes an issue)

## Checklist:

- [x] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.


[CDAR-875]: https://usdot-carma.atlassian.net/browse/CDAR-875?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ