### PR TITLE
fix ped_detection moving to start of time

### DIFF
--- a/vru_use_case_scripts/plot_deceleration
+++ b/vru_use_case_scripts/plot_deceleration
@@ -210,7 +210,7 @@ def plot_deceleration_and_speed(ros_bag_file, show_plot, figure_dir, max_deceler
 
     # NOTE: Object can get detected very early on due to CP
     # therefore, for better plotting we take the max of first time platform engaged and object detected
-    detected_t_sec = adjusted_time_stamps[0] if detected_t_sec is None else detected_t_sec
+    detected_t_sec = adjusted_time_stamps[-1] if detected_t_sec is None else max(detected_t_sec, adjusted_time_stamps[0])
 
     # Also if the actors never achieved the events we are tracking, move the line to the end of the plot
     started_moving_t_sec = adjusted_time_stamps[-1] if started_moving_t_sec is None else started_moving_t_sec


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description

<!--- Describe your changes in detail -->
Fixing bug introduced in this PR: https://github.com/usdot-fhwa-stol/carma-analytics-fotda/pull/57
## Related GitHub Issue

<!--- This project only accepts pull requests related to open GitHub issues or Jira Keys -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please DO NOT name partially fixed issues, instead open an issue specific to this fix -->
<!--- Please link to the issue here: -->

## Related Jira Key

<!-- e.g. CAR-123 -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
