### PR TITLE
switched to first-order splines

### DIFF
--- a/src/carma-1-tenth/plot_crosstrack_error.py
+++ b/src/carma-1-tenth/plot_crosstrack_error.py
@@ -64,8 +64,9 @@ def plot_absolute_route_deviation(bag_dir, start_offset=0.0):
     for i in range(len(route_graph.markers)):
         if route_graph.markers[i].type == 2:
             route_coordinates.append([-route_graph.markers[i].pose.position.y, route_graph.markers[i].pose.position.x])
+    route_coordinates = np.array(route_coordinates)
     route_coordinates_with_distance = np.zeros((len(route_coordinates), 3))
-    route_coordinates_with_distance[:, 1:] = np.array(route_coordinates)
+    route_coordinates_with_distance[:, 1:] = route_coordinates
     running_distance = 0.0
     # Assign a distance along the route for each x,y coordinate along the route
     for i in range(len(route_coordinates)):
@@ -73,8 +74,8 @@ def plot_absolute_route_deviation(bag_dir, start_offset=0.0):
             running_distance += np.linalg.norm(route_coordinates_with_distance[i, 1:] - route_coordinates_with_distance[i-1, 1:])
         route_coordinates_with_distance[i,0] = running_distance
     # Fit 2D splines that map the distance along the route to the x and y coordinates to upsample the points
-    x_spline = make_interp_spline(route_coordinates_with_distance[:,0], route_coordinates_with_distance[:,1])
-    y_spline = make_interp_spline(route_coordinates_with_distance[:,0], route_coordinates_with_distance[:,2])
+    x_spline = make_interp_spline(route_coordinates_with_distance[:,0], route_coordinates_with_distance[:,1], k=1)
+    y_spline = make_interp_spline(route_coordinates_with_distance[:,0], route_coordinates_with_distance[:,2], k=1)
     samples = np.linspace(route_coordinates_with_distance[0,0], route_coordinates_with_distance[-1,0], 10000)
     route_x_points = x_spline(samples)
     route_y_points = y_spline(samples)
@@ -97,6 +98,8 @@ def plot_absolute_route_deviation(bag_dir, start_offset=0.0):
 
     print("Average Deviation:", np.mean(np.abs(route_deviations)))
     print("Maximum Deviation:", np.max(np.abs(route_deviations)))
+    # plt.plot(route_x_points, route_y_points)
+    # plt.plot(route_coordinates[:,0], route_coordinates[:,1], '.r')
     plt.plot(distances_along_route, route_deviations, label="Crosstrack Error")
     plt.plot(distances_along_route, np.zeros(len(route_deviations)), label="Route")
 

--- a/src/carma-1-tenth/plot_crosstrack_error.py
+++ b/src/carma-1-tenth/plot_crosstrack_error.py
@@ -98,8 +98,6 @@ def plot_absolute_route_deviation(bag_dir, start_offset=0.0):
 
     print("Average Deviation:", np.mean(np.abs(route_deviations)))
     print("Maximum Deviation:", np.max(np.abs(route_deviations)))
-    # plt.plot(route_x_points, route_y_points)
-    # plt.plot(route_coordinates[:,0], route_coordinates[:,1], '.r')
     plt.plot(distances_along_route, route_deviations, label="Crosstrack Error")
     plt.plot(distances_along_route, np.zeros(len(route_deviations)), label="Route")
 


### PR DESCRIPTION
# PR Details
## Description

The script used to generate the C1T crosstrack vs. downtrack visualization has been shown to poorly fit splines to the route graph, which causes the reported crosstrack error to be higher than what is actually experienced. This PR includes a fix to improve spline fitment and report more accurate crosstrack error.

## Related Jira Key


## Motivation and Context

Crosstrack error is an important metric to track as we establish the performance capabilities and limitations of the C1T system, so accurately reporting this metric is crucial.

## How Has This Been Tested?

New splines were fit to a route driven in the main lab and visualized. The crosstrack vs. downtrack error was also compared to the route-driven in 2D space and visually better aligns with the deviations experienced by the truck.

## Types of changes

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
