### PR TITLE
Cf 871 Blue Truck Debugging

### DIFF
--- a/src/carma-1-tenth/plot_crosstrack_error.py
+++ b/src/carma-1-tenth/plot_crosstrack_error.py
@@ -30,7 +30,7 @@ def is_left(route_a, route_b, odometry):
         return False
 
 
-def plot_absolute_route_deviation(bag_dir, show_plots=True):
+def plot_crosstrack_error(bag_dir, show_plots=True):
     metadatafile : str = os.path.join(bag_dir, "metadata.yaml")
     if not os.path.isfile(metadatafile):
         raise ValueError("Metadata file %s does not exist. Are you sure %s is a valid rosbag?" % (metadatafile, bag_dir))
@@ -101,6 +101,7 @@ def plot_absolute_route_deviation(bag_dir, show_plots=True):
     if show_plots:
         plt.plot(distances_along_route, route_deviations, label="Crosstrack Error")
         plt.plot(distances_along_route, np.zeros(len(route_deviations)), label="Route")
+    return distances_along_route, route_deviations
 
 
 if __name__=="__main__":
@@ -110,7 +111,7 @@ if __name__=="__main__":
     argcomplete.autocomplete(parser)
     args = parser.parse_args()
     argdict : dict = vars(args)
-    plot_absolute_route_deviation(os.path.normpath(os.path.abspath(argdict["bag_in"])))
+    plot_crosstrack_error(os.path.normpath(os.path.abspath(argdict["bag_in"])))
     plt.xlabel("Downtrack (m)")
     plt.ylabel("Crosstrack Error (m)")
     plt.title("Crosstrack Error vs. Downtrack")

--- a/src/carma-1-tenth/plot_crosstrack_error.py
+++ b/src/carma-1-tenth/plot_crosstrack_error.py
@@ -13,11 +13,11 @@ import argparse, argcomplete
 import os
 
 
-def find_closest_point(point_arr, point):
+def find_closest_point(point_arr, point, trim_ends=True):
     difference_arr = np.linalg.norm(point_arr - point, axis=1)
     min_index = difference_arr.argmin()
     # Don't want to include deviations if we have not yet reached the route or have completed it
-    if min_index == 0 or min_index == len(difference_arr) - 1:
+    if trim_ends and (min_index == 0 or min_index == len(difference_arr) - 1):
         return None, None
     return point_arr[min_index], min_index
 

--- a/src/carma-1-tenth/plot_multiple_crosstrack_errors.py
+++ b/src/carma-1-tenth/plot_multiple_crosstrack_errors.py
@@ -1,4 +1,4 @@
-# Plot the crosstrack error as a function of downtrack (distance traveled along the route)
+# Generate a box plot that benchmarks the route tracking performance of the red and blue C1T trucks at varying speeds
 
 
 import numpy as np
@@ -6,25 +6,52 @@ import matplotlib.pyplot as plt
 from matplotlib.patches import Polygon
 import argparse, argcomplete
 import os
+import yaml
 from plot_crosstrack_error import plot_crosstrack_error
 
 
-def plot_multiple_crosstrack_errors(red_point_five_bag, red_point_seven_bag, red_one_bag, blue_point_five_bag, blue_point_seven_bag, blue_one_bag, show_plots=True):
-    _, red_point_five_crosstrack_errors = plot_crosstrack_error(red_point_five_bag, show_plots=False)
-    _, red_point_seven_crosstrack_errors = plot_crosstrack_error(red_point_seven_bag, show_plots=False)
-    _, red_one_crosstrack_errors = plot_crosstrack_error(red_one_bag, show_plots=False)
-    _, blue_point_five_crosstrack_errors = plot_crosstrack_error(blue_point_five_bag, show_plots=False)
-    _, blue_point_seven_crosstrack_errors = plot_crosstrack_error(blue_point_seven_bag, show_plots=False)
-    _, blue_one_crosstrack_errors = plot_crosstrack_error(blue_one_bag, show_plots=False)
+def plot_multiple_crosstrack_errors(bags, show_plots=True):
+    bag_metadata = []
+    for bag in bags:
+        bag_path = os.path.normpath(os.path.abspath(bag))
+        if os.path.isfile(os.path.join(bag_path, "red_truck_params.yaml")):
+            truck = "red"
+            params_file = os.path.join(bag_path, "red_truck_params.yaml")
+        elif os.path.isfile(os.path.join(bag_path, "blue_truck_params.yaml")):
+            truck = "blue"
+            params_file = os.path.join(bag_path, "blue_truck_params.yaml")
+        else:
+            raise ValueError("%s does not have a parameters file. Exiting..." % (bag_path,))
+        with open(params_file, "r") as f:
+            speed = yaml.load(f, Loader=yaml.SafeLoader)["controller_server"]["ros__parameters"]["FollowPath"]["desired_linear_vel"]
+        bag_metadata.append((bag_path, truck, speed))
+    red_truck_data, blue_truck_data = [], []
+    red_truck_speeds, blue_truck_speeds = [], []
+    for run in bag_metadata:
+        _, crosstrack_errors = plot_crosstrack_error(run[0], show_plots=False)
+        if run[1] == "red":
+            red_truck_data.append(np.abs(crosstrack_errors))
+            red_truck_speeds.append(run[2])
+        else:
+            blue_truck_data.append(np.abs(crosstrack_errors))
+            blue_truck_speeds.append(run[2])
 
-    data = [np.sort(np.abs(red_point_five_crosstrack_errors)),
-            np.sort(np.abs(red_point_seven_crosstrack_errors)),
-            np.sort(np.abs(red_one_crosstrack_errors)),
-            np.sort(np.abs(blue_point_five_crosstrack_errors)),
-            np.sort(np.abs(blue_point_seven_crosstrack_errors)),
-            np.sort(np.abs(blue_one_crosstrack_errors))]
+    red_truck_sort = np.argsort(red_truck_speeds)
+    red_truck_sorted_data = []
+    red_truck_sorted_speeds = []
+    for i in red_truck_sort:
+        red_truck_sorted_data.append(red_truck_data[i])
+        red_truck_sorted_speeds.append(red_truck_speeds[i])
 
-    box_colors = ["darksalmon", "cornflowerblue"]
+    blue_truck_sort = np.argsort(blue_truck_speeds)
+    blue_truck_sorted_data = []
+    blue_truck_sorted_speeds = []
+    for i in blue_truck_sort:
+        blue_truck_sorted_data.append(blue_truck_data[i])
+        blue_truck_sorted_speeds.append(blue_truck_speeds[i])
+
+    data = red_truck_sorted_data + blue_truck_sorted_data
+
     if show_plots:
         fig, ax = plt.subplots(figsize=(10, 6))
         bp = ax.boxplot(data, medianprops = dict(color = "black", linewidth = 1.5))
@@ -36,35 +63,27 @@ def plot_multiple_crosstrack_errors(red_point_five_bag, red_point_seven_bag, red
                 box_x.append(box.get_xdata()[j])
                 box_y.append(box.get_ydata()[j])
             box_coords = np.column_stack([box_x, box_y])
-            # Alternate between Dark Khaki and Royal Blue
-            ax.add_patch(Polygon(box_coords, facecolor=box_colors[i // 3]))
-        ax.set_xticklabels(["0.5", "0.7", "1.0", "0.5", "0.7", "1.0"])
+            if i < len(red_truck_data):
+                ax.add_patch(Polygon(box_coords, facecolor="darksalmon"))
+            else:
+                ax.add_patch(Polygon(box_coords, facecolor="cornflowerblue"))
+        ax.set_xticklabels([str(speed) for speed in red_truck_sorted_speeds + blue_truck_sorted_speeds])
         fig.text(0.925, 0.85, 'Red Truck',
-         backgroundcolor=box_colors[0], color='black', weight='roman',
+         backgroundcolor="darksalmon", color='black', weight='roman',
          size='x-small')
         fig.text(0.925, 0.815, 'Blue Truck',
-         backgroundcolor=box_colors[1],
+         backgroundcolor="cornflowerblue",
          color='white', weight='roman', size='x-small')
 
 
 if __name__=="__main__":
     parser = argparse.ArgumentParser(description="Generate box plots for multiple runs of C1T vehicles")
-    parser.add_argument("red_0.5_bag", type=str, help="Directory of bag to load for red truck traveling at 0.5 m/s")
-    parser.add_argument("red_0.7_bag", type=str, help="Directory of bag to load for red truck traveling at 0.7 m/s")
-    parser.add_argument("red_1.0_bag", type=str, help="Directory of bag to load for red truck traveling at 1.0 m/s")
-    parser.add_argument("blue_0.5_bag", type=str, help="Directory of bag to load for blue truck traveling at 0.5 m/s")
-    parser.add_argument("blue_0.7_bag", type=str, help="Directory of bag to load for blue truck traveling at 0.7 m/s")
-    parser.add_argument("blue_1.0_bag", type=str, help="Directory of bag to load for blue truck traveling at 1.0 m/s")
+    parser.add_argument("bags", type=str, help="Directories of bags to load", nargs='*')
     parser.add_argument("--png_out", type=str, help="File path to save the plot")
     argcomplete.autocomplete(parser)
     args = parser.parse_args()
     argdict : dict = vars(args)
-    plot_multiple_crosstrack_errors(os.path.normpath(os.path.abspath(argdict["red_0.5_bag"])),
-                                    os.path.normpath(os.path.abspath(argdict["red_0.7_bag"])),
-                                    os.path.normpath(os.path.abspath(argdict["red_1.0_bag"])),
-                                    os.path.normpath(os.path.abspath(argdict["blue_0.5_bag"])),
-                                    os.path.normpath(os.path.abspath(argdict["blue_0.7_bag"])),
-                                    os.path.normpath(os.path.abspath(argdict["blue_1.0_bag"])))
+    plot_multiple_crosstrack_errors(argdict["bags"])
     plt.xlabel("Vehicle Speed (m/s)")
     plt.ylabel("Crosstrack Error (m)")
     plt.title("Crosstrack Error at Varying Speeds")

--- a/src/carma-1-tenth/plot_multiple_crosstrack_errors.py
+++ b/src/carma-1-tenth/plot_multiple_crosstrack_errors.py
@@ -1,0 +1,73 @@
+# Plot the crosstrack error as a function of downtrack (distance traveled along the route)
+
+
+import numpy as np
+import matplotlib.pyplot as plt
+from matplotlib.patches import Polygon
+import argparse, argcomplete
+import os
+from plot_crosstrack_error import plot_crosstrack_error
+
+
+def plot_multiple_crosstrack_errors(red_point_five_bag, red_point_seven_bag, red_one_bag, blue_point_five_bag, blue_point_seven_bag, blue_one_bag, show_plots=True):
+    _, red_point_five_crosstrack_errors = plot_crosstrack_error(red_point_five_bag, show_plots=False)
+    _, red_point_seven_crosstrack_errors = plot_crosstrack_error(red_point_seven_bag, show_plots=False)
+    _, red_one_crosstrack_errors = plot_crosstrack_error(red_one_bag, show_plots=False)
+    _, blue_point_five_crosstrack_errors = plot_crosstrack_error(blue_point_five_bag, show_plots=False)
+    _, blue_point_seven_crosstrack_errors = plot_crosstrack_error(blue_point_seven_bag, show_plots=False)
+    _, blue_one_crosstrack_errors = plot_crosstrack_error(blue_one_bag, show_plots=False)
+
+    data = [np.sort(np.abs(red_point_five_crosstrack_errors)),
+            np.sort(np.abs(red_point_seven_crosstrack_errors)),
+            np.sort(np.abs(red_one_crosstrack_errors)),
+            np.sort(np.abs(blue_point_five_crosstrack_errors)),
+            np.sort(np.abs(blue_point_seven_crosstrack_errors)),
+            np.sort(np.abs(blue_one_crosstrack_errors))]
+
+    box_colors = ["darksalmon", "cornflowerblue"]
+    if show_plots:
+        fig, ax = plt.subplots(figsize=(10, 6))
+        bp = ax.boxplot(data, medianprops = dict(color = "black", linewidth = 1.5))
+        for i in range(len(data)):
+            box = bp['boxes'][i]
+            box_x = []
+            box_y = []
+            for j in range(5):
+                box_x.append(box.get_xdata()[j])
+                box_y.append(box.get_ydata()[j])
+            box_coords = np.column_stack([box_x, box_y])
+            # Alternate between Dark Khaki and Royal Blue
+            ax.add_patch(Polygon(box_coords, facecolor=box_colors[i // 3]))
+        ax.set_xticklabels(["0.5", "0.7", "1.0", "0.5", "0.7", "1.0"])
+        fig.text(0.925, 0.85, 'Red Truck',
+         backgroundcolor=box_colors[0], color='black', weight='roman',
+         size='x-small')
+        fig.text(0.925, 0.815, 'Blue Truck',
+         backgroundcolor=box_colors[1],
+         color='white', weight='roman', size='x-small')
+
+
+if __name__=="__main__":
+    parser = argparse.ArgumentParser(description="Generate box plots for multiple runs of C1T vehicles")
+    parser.add_argument("red_0.5_bag", type=str, help="Directory of bag to load for red truck traveling at 0.5 m/s")
+    parser.add_argument("red_0.7_bag", type=str, help="Directory of bag to load for red truck traveling at 0.7 m/s")
+    parser.add_argument("red_1.0_bag", type=str, help="Directory of bag to load for red truck traveling at 1.0 m/s")
+    parser.add_argument("blue_0.5_bag", type=str, help="Directory of bag to load for blue truck traveling at 0.5 m/s")
+    parser.add_argument("blue_0.7_bag", type=str, help="Directory of bag to load for blue truck traveling at 0.7 m/s")
+    parser.add_argument("blue_1.0_bag", type=str, help="Directory of bag to load for blue truck traveling at 1.0 m/s")
+    parser.add_argument("--png_out", type=str, help="File path to save the plot")
+    argcomplete.autocomplete(parser)
+    args = parser.parse_args()
+    argdict : dict = vars(args)
+    plot_multiple_crosstrack_errors(os.path.normpath(os.path.abspath(argdict["red_0.5_bag"])),
+                                    os.path.normpath(os.path.abspath(argdict["red_0.7_bag"])),
+                                    os.path.normpath(os.path.abspath(argdict["red_1.0_bag"])),
+                                    os.path.normpath(os.path.abspath(argdict["blue_0.5_bag"])),
+                                    os.path.normpath(os.path.abspath(argdict["blue_0.7_bag"])),
+                                    os.path.normpath(os.path.abspath(argdict["blue_1.0_bag"])))
+    plt.xlabel("Vehicle Speed (m/s)")
+    plt.ylabel("Crosstrack Error (m)")
+    plt.title("Crosstrack Error at Varying Speeds")
+    if argdict["png_out"]:
+        plt.savefig(argdict["png_out"])
+    plt.show()

--- a/src/carma-1-tenth/plot_route_driven.py
+++ b/src/carma-1-tenth/plot_route_driven.py
@@ -69,10 +69,8 @@ def plot_route_driven(bag_dir, show_plots=True):
             closest_odom_to_route, _ = find_closest_point(odometry, route_coordinate, trim_ends=False)
             route_coordinate_downtrack_distance = map_coords_to_downtrack[tuple(route_coordinate)]
             std_deviation_at_route_coordinate = particle_std_deviations[np.abs(route_coordinate_downtrack_distance - particle_distances_along_route).argmin()]
-            print(closest_odom_to_route)
             e2 = Ellipse(closest_odom_to_route, 2.0 * std_deviation_at_route_coordinate[0], 2.0 * std_deviation_at_route_coordinate[1], color='b', fill=False, ls="--")
             ax.add_patch(e2)
-    print(route_downtrack_distances)
 
 
 if __name__=="__main__":

--- a/src/carma-1-tenth/plot_route_driven.py
+++ b/src/carma-1-tenth/plot_route_driven.py
@@ -66,9 +66,10 @@ def plot_route_driven(bag_dir, show_plots=True):
         ax = plt.gca()
         particle_distances_along_route, particle_std_deviations = plot_localization(bag_dir, show_plots=False)
         for route_coordinate in route_graph_coordinates:
-            closest_odom_to_route, _ = find_closest_point(odometry, route_coordinate)
+            closest_odom_to_route, _ = find_closest_point(odometry, route_coordinate, trim_ends=False)
             route_coordinate_downtrack_distance = map_coords_to_downtrack[tuple(route_coordinate)]
             std_deviation_at_route_coordinate = particle_std_deviations[np.abs(route_coordinate_downtrack_distance - particle_distances_along_route).argmin()]
+            print(closest_odom_to_route)
             e2 = Ellipse(closest_odom_to_route, 2.0 * std_deviation_at_route_coordinate[0], 2.0 * std_deviation_at_route_coordinate[1], color='b', fill=False, ls="--")
             ax.add_patch(e2)
     print(route_downtrack_distances)


### PR DESCRIPTION
# PR Details
## Description

This PR includes a new script that compares the red and blue truck route tracking performance at varying speeds. Additionally, a bug fix for plotting the route driven is included.

## Related Jira Key

[CF-871](https://usdot-carma.atlassian.net/browse/CF-871)

## Motivation and Context

The Blue Truck had previously been locked into first gear using zipties. This was causing drive issues, so they were removed. After being removed the truck defaults to 2nd gear which has improved driving smoothness but localization quality has been negatively affected. It is likely that the VESC drive parameters need to be updated and a new parameter file will need to be created to delineate the two C1T trucks.

## How Has This Been Tested?

Data was collected from both trucks and plotted using the tool

## Types of changes

- [x] Defect fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


[CF-871]: https://usdot-carma.atlassian.net/browse/CF-871?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ