### PR TITLE
Fix/reorder metrics

### DIFF
--- a/src/carma-1-tenth/check_distance_to_arrival.py
+++ b/src/carma-1-tenth/check_distance_to_arrival.py
@@ -26,7 +26,7 @@ def check_distance_to_arrival(bag_dir):
     goal_topic = '/incoming_mobility_operation'
     ack_topic = '/outgoing_mobility_operation'
     # Open bag
-    reader, type_map = open_bagfile(bag_dir, topics=[goal_topic, ack_topic], storage_id=storage_id)
+    reader, type_map = open_bagfile(bag_dir, topics=[goal_topic, ack_topic, rviz_topic], storage_id=storage_id)
     # Gather number of messages on each topic
     topic_count_dict = {entry["topic_metadata"]["name"] : entry["message_count"] for entry in metadata_dict["topics_with_message_count"]}
     if rviz_topic not in topic_count_dict:

--- a/src/carma-1-tenth/check_port_drayage_ack.py
+++ b/src/carma-1-tenth/check_port_drayage_ack.py
@@ -48,16 +48,18 @@ def check_port_drayage_ack(bag_dir, operation):
                     elif operation == "DROPOFF":
                         goal_cargo_id = ""
                     else:
-                        raise ValueError("Unsupported operation %s, please use PICKUP, DROPOFF, or HOLDING_AREA")
+                        return True
             elif topic == ack_topic:
                 strategy_params = json.loads(msg.strategy_params)
                 # Check the ack message for the desired operation has the correct cargo_id
                 if strategy_params["operation"] == operation:
-                    if (strategy_params["operation"] == "PICKUP" or strategy_params["operation"] == "HOLDING_AREA") and strategy_params["cargo_id"] == goal_cargo_id:
+                    if (strategy_params["operation"] == "PICKUP" or strategy_params["operation"] == "HOLDING_AREA") and strategy_params["cargo_id"] != goal_cargo_id:
+                        return False
+                    elif strategy_params["operation"] == "DROPOFF" and strategy_params["cargo"]:
+                        return False
+                    else:
                         return True
-                    elif strategy_params["operation"] == "DROPOFF" and not strategy_params["cargo"]:
-                        return True
-    # Return true if desired operation is not in the bag
+    # Return true if desired operation was not in bag
     return True
 
 if __name__=="__main__":

--- a/src/carma-1-tenth/run_c1t_metric_analysis.py
+++ b/src/carma-1-tenth/run_c1t_metric_analysis.py
@@ -99,7 +99,7 @@ class C1TMetricAnalysis(unittest.TestCase):
     def test_C1T_07_stops_close_to_destination(self):
         # The C1T CMV stops within 0.5 m of the goal destinations
         arrival_distances = check_distance_to_arrival(self.bag_dir)
-        self.assertTrue(np.all(arrival_distances < 0.5), "Vehicle did not stop within 0.2 m of goal destination")
+        self.assertTrue(np.all(arrival_distances < 0.5), "Vehicle did not stop within 0.5 m of goal destination")
 
     def test_C1T_08_acks_with_MOM(self):
         # The C1T CMV sends Mobility Operation message acknowledging when a goal is reached

--- a/src/carma-1-tenth/run_c1t_metric_analysis.py
+++ b/src/carma-1-tenth/run_c1t_metric_analysis.py
@@ -24,31 +24,21 @@ class C1TMetricAnalysis(unittest.TestCase):
         set_logger_level("rosbag2_storage", get_logging_severity_from_string("FATAL"))
         
 
-    def test_C1T_01_generates_route_from_MOM(self):
-        # The C1T CMV is able to receive destinations as Mobility Operation messages from the infrastructure and generate a route
-        self.assertTrue(check_message_published(self.bag_dir, "/plan"), "Message was not received on /plan")
-
-    def test_C1T_02_generates_route_from_rviz_timing(self):
+    def test_C1T_01_generates_route_from_rviz_timing(self):
         # The C1T CMV will generate a route within 3 seconds of receiving a goal pose from Rviz
         time_between_messages = check_message_timing(self.bag_dir, "/goal_pose", "/plan")
         self.assertTrue(np.all(time_between_messages < 3.0), "Time between messages on /goal_pose and /plan exceeded 3 seconds")
 
-    def test_C1T_03_generates_route_from_MOM_timing(self):
-        # The C1T CMV will generate a route within 3 seconds of receiving an incoming mobility operation message
-        time_between_messages = check_message_timing(self.bag_dir, "/incoming_mobility_operation", "/plan")
-        self.assertTrue(np.all(time_between_messages < 3.0), "Time between messages on /incoming_mobility_operation and /plan exceeded 3 seconds")
+    def test_C1T_02_generates_route_from_MOM(self):
+        # The C1T CMV is able to receive destinations as Mobility Operation messages from the infrastructure and generate a route
+        self.assertTrue(check_message_published(self.bag_dir, "/plan"), "Message was not received on /plan")
 
-    def test_C1T_04_follow_route(self):
-        # The C1T CMV will follow its generate routed to the destination with less than 0.4 m of crosstrack error 
-        _, crosstrack_errors = plot_crosstrack_error(self.bag_dir, "/plan", show_plots=False)
-        self.assertTrue(np.all(crosstrack_errors < 0.4), "Crosstrack error from planned route exceeded 0.4 m")
-
-    def test_C1T_05_follows_road_network(self):
+    def test_C1T_03_follows_road_network(self):
         # The C1T CMV will drive along the centerline of the defined road network with less than 0.2 m of crosstrack error
         _, crosstrack_errors = plot_crosstrack_error(self.bag_dir, "/route_graph", show_plots=False)
         self.assertTrue(np.all(np.abs(crosstrack_errors) < 0.2), "Crosstrack error from road network exceeded 0.2 m")
 
-    def test_C1T_06_maintains_speed_on_straights(self):
+    def test_C1T_04_maintains_speed_on_straights(self):
         # The C1T CMV achieves and maintains its target speed with a tolerance of 0.2 m/s (excluding turns)
         velocities, target_velocities = plot_vehicle_speed(self.bag_dir, show_plots=False)
         max_target_speed = np.max(target_velocities)
@@ -68,7 +58,7 @@ class C1TMetricAnalysis(unittest.TestCase):
         speeds_on_straights = velocities[relevant_velocity_idxs]
         self.assertTrue(np.all(np.abs(max_target_speed - speeds_on_straights) < 0.2), "Vehicle deviated more than 0.2 m/s from target speed on straight")
 
-    def test_C1T_07_slowdown_on_turns(self):
+    def test_C1T_05_slowdown_on_turns(self):
         # The C1T CMV will not slowdown less than 50% of the target speed during turns
         velocities, target_velocities = plot_vehicle_speed(self.bag_dir, show_plots=False)
         max_target_speed = np.max(target_velocities)
@@ -100,14 +90,19 @@ class C1TMetricAnalysis(unittest.TestCase):
         speeds_on_turns = velocities[relevant_velocity_idxs]
         self.assertTrue(np.all(speeds_on_turns > 0.5 * max_target_speed), "Vehicle speed reduced more than 50% on turn")
 
-    def test_C1T_08_stops_close_to_destination(self):
+    def test_C1T_06_stops_close_to_destination(self):
         # The C1T CMV stops within 0.2 m of the goal destinations
         arrival_distances = check_distance_to_arrival(self.bag_dir)
         self.assertTrue(np.all(arrival_distances < 0.2), "Vehicle did not stop within 0.2 m of goal destination")
 
-    def test_C1T_09_acks_with_MOM(self):
+    def test_C1T_07_acks_with_MOM(self):
         # The C1T CMV sends Mobility Operation message acknowledging when a goal is reached
         self.assertTrue(check_message_published(self.bag_dir, "/outgoing_mobility_operation"), "Message not received on /outgoing_mobility_operation")
+
+    def test_C1T_09_generates_route_from_MOM_timing(self):
+        # The C1T CMV will generate a route within 3 seconds of receiving an incoming mobility operation message
+        time_between_messages = check_message_timing(self.bag_dir, "/incoming_mobility_operation", "/plan")
+        self.assertTrue(np.all(time_between_messages < 3.0), "Time between messages on /incoming_mobility_operation and /plan exceeded 3 seconds")
 
     def test_C1T_10_infrastructure_response_to_ack_timing(self):
         # Infrastructure responds within a new goal destination within 1.5 seconds of receiving an ack from the C1T CMV
@@ -119,7 +114,7 @@ class C1TMetricAnalysis(unittest.TestCase):
         self.assertTrue(check_port_drayage_ack(self.bag_dir, "PICKUP"), "Vehicle did not ack PICKUP correctly")
         self.assertTrue(check_port_drayage_ack(self.bag_dir, "DROPOFF"), "Vehicle did not ack DROPOFF correctly")
 
-    def test_C1T_13_communicate_inspection(self):
+    def test_C1T_16_communicate_inspection(self):
         # Infrastructure can communicate with the C1T CMV that the container is inspected
         self.assertTrue(check_port_drayage_ack(self.bag_dir, "HOLDING_AREA"), "Vehicle did not ack HOLDING_AREA corectly")
     

--- a/src/carma-1-tenth/run_c1t_metric_analysis.py
+++ b/src/carma-1-tenth/run_c1t_metric_analysis.py
@@ -34,9 +34,15 @@ class C1TMetricAnalysis(unittest.TestCase):
         self.assertTrue(check_message_published(self.bag_dir, "/plan"), "Message was not received on /plan")
 
     def test_C1T_03_follows_road_network(self):
-        # The C1T CMV will drive along the centerline of the defined road network with less than 0.2 m of crosstrack error
+        # The C1T CMV will drive along the centerline of the defined road network with less than 0.2 m of crosstrack error 95% of the time
         _, crosstrack_errors = plot_crosstrack_error(self.bag_dir, "/route_graph", show_plots=False)
-        self.assertTrue(np.all(np.abs(crosstrack_errors) < 0.2), "Crosstrack error from road network exceeded 0.2 m")
+        crosstrack_error_ratio = np.sum(np.abs(crosstrack_errors) < 0.2) / len(crosstrack_errors)
+        self.assertTrue(crosstrack_error_ratio > 0.95, "Crosstrack error from road network exceeded 0.2 m")
+
+    def test_C1T_04_follows_road_network(self):
+        # The C1T CMV will drive along the centerline of the defined road network with less than 0.3 m of crosstrack error
+        _, crosstrack_errors = plot_crosstrack_error(self.bag_dir, "/route_graph", show_plots=False)
+        self.assertTrue(np.all(np.abs(crosstrack_errors) < 0.3), "Crosstrack error from road network exceeded 0.2 m")
 
     def test_C1T_04_maintains_speed_on_straights(self):
         # The C1T CMV achieves and maintains its target speed with a tolerance of 0.2 m/s (excluding turns)

--- a/src/carma-1-tenth/run_c1t_metric_analysis.py
+++ b/src/carma-1-tenth/run_c1t_metric_analysis.py
@@ -97,7 +97,7 @@ class C1TMetricAnalysis(unittest.TestCase):
         self.assertTrue(np.all(speeds_on_turns > 0.5 * max_target_speed), "Vehicle speed reduced more than 50% on turn")
 
     def test_C1T_07_stops_close_to_destination(self):
-        # The C1T CMV stops within 0.2 m of the goal destinations
+        # The C1T CMV stops within 0.5 m of the goal destinations
         arrival_distances = check_distance_to_arrival(self.bag_dir)
         self.assertTrue(np.all(arrival_distances < 0.5), "Vehicle did not stop within 0.2 m of goal destination")
 

--- a/src/carma-1-tenth/run_c1t_metric_analysis.py
+++ b/src/carma-1-tenth/run_c1t_metric_analysis.py
@@ -99,20 +99,23 @@ class C1TMetricAnalysis(unittest.TestCase):
         # The C1T CMV sends Mobility Operation message acknowledging when a goal is reached
         self.assertTrue(check_message_published(self.bag_dir, "/outgoing_mobility_operation"), "Message not received on /outgoing_mobility_operation")
 
+    def test_C1T_08_receives_incoming_MOM(self):
+        # The C1T CMV sends Mobility Operation message acknowledging when a goal is reached
+        self.assertTrue(check_message_published(self.bag_dir, "/incoming_mobility_operation"), "Message not received on /incoming_mobility_operation")
+
     def test_C1T_09_generates_route_from_MOM_timing(self):
         # The C1T CMV will generate a route within 3 seconds of receiving an incoming mobility operation message
         time_between_messages = check_message_timing(self.bag_dir, "/incoming_mobility_operation", "/plan")
         self.assertTrue(np.all(time_between_messages < 3.0), "Time between messages on /incoming_mobility_operation and /plan exceeded 3 seconds")
 
-    def test_C1T_10_infrastructure_response_to_ack_timing(self):
-        # Infrastructure responds within a new goal destination within 1.5 seconds of receiving an ack from the C1T CMV
-        time_between_messages = check_message_timing(self.bag_dir, "/outgoing_mobility_operation", "/incoming_mobility_operation")
-        self.assertTrue(np.all(time_between_messages < 1.5), "Time between ack and new goal exceed 1.5 seconds")
-
     def test_C1T_12_communicate_load_and_unload(self):
         # Infrastructure can communicate with the C1T CMV that the container is loaded and unloaded
         self.assertTrue(check_port_drayage_ack(self.bag_dir, "PICKUP"), "Vehicle did not ack PICKUP correctly")
         self.assertTrue(check_port_drayage_ack(self.bag_dir, "DROPOFF"), "Vehicle did not ack DROPOFF correctly")
+
+    def test_C1T_13_communicate_checkpoint(self):
+        # Infrastructure can communicate with the C1T CMV that the container is loaded and unloaded
+        self.assertTrue(check_port_drayage_ack(self.bag_dir, "PORT_CHECKPOINT"), "Vehicle did not ack PORT_CHECKPOINT")
 
     def test_C1T_16_communicate_inspection(self):
         # Infrastructure can communicate with the C1T CMV that the container is inspected

--- a/src/carma-1-tenth/run_c1t_metric_analysis.py
+++ b/src/carma-1-tenth/run_c1t_metric_analysis.py
@@ -44,7 +44,7 @@ class C1TMetricAnalysis(unittest.TestCase):
         _, crosstrack_errors = plot_crosstrack_error(self.bag_dir, "/route_graph", show_plots=False)
         self.assertTrue(np.all(np.abs(crosstrack_errors) < 0.3), "Crosstrack error from road network exceeded 0.2 m")
 
-    def test_C1T_04_maintains_speed_on_straights(self):
+    def test_C1T_05_maintains_speed_on_straights(self):
         # The C1T CMV achieves and maintains its target speed with a tolerance of 0.2 m/s (excluding turns)
         velocities, target_velocities = plot_vehicle_speed(self.bag_dir, show_plots=False)
         max_target_speed = np.max(target_velocities)
@@ -64,7 +64,7 @@ class C1TMetricAnalysis(unittest.TestCase):
         speeds_on_straights = velocities[relevant_velocity_idxs]
         self.assertTrue(np.all(np.abs(max_target_speed - speeds_on_straights) < 0.2), "Vehicle deviated more than 0.2 m/s from target speed on straight")
 
-    def test_C1T_05_slowdown_on_turns(self):
+    def test_C1T_06_slowdown_on_turns(self):
         # The C1T CMV will not slowdown less than 50% of the target speed during turns
         velocities, target_velocities = plot_vehicle_speed(self.bag_dir, show_plots=False)
         max_target_speed = np.max(target_velocities)
@@ -96,34 +96,34 @@ class C1TMetricAnalysis(unittest.TestCase):
         speeds_on_turns = velocities[relevant_velocity_idxs]
         self.assertTrue(np.all(speeds_on_turns > 0.5 * max_target_speed), "Vehicle speed reduced more than 50% on turn")
 
-    def test_C1T_06_stops_close_to_destination(self):
+    def test_C1T_07_stops_close_to_destination(self):
         # The C1T CMV stops within 0.2 m of the goal destinations
         arrival_distances = check_distance_to_arrival(self.bag_dir)
-        self.assertTrue(np.all(arrival_distances < 0.2), "Vehicle did not stop within 0.2 m of goal destination")
+        self.assertTrue(np.all(arrival_distances < 0.5), "Vehicle did not stop within 0.2 m of goal destination")
 
-    def test_C1T_07_acks_with_MOM(self):
+    def test_C1T_08_acks_with_MOM(self):
         # The C1T CMV sends Mobility Operation message acknowledging when a goal is reached
         self.assertTrue(check_message_published(self.bag_dir, "/outgoing_mobility_operation"), "Message not received on /outgoing_mobility_operation")
 
-    def test_C1T_08_receives_incoming_MOM(self):
+    def test_C1T_09_receives_incoming_MOM(self):
         # The C1T CMV sends Mobility Operation message acknowledging when a goal is reached
         self.assertTrue(check_message_published(self.bag_dir, "/incoming_mobility_operation"), "Message not received on /incoming_mobility_operation")
 
-    def test_C1T_09_generates_route_from_MOM_timing(self):
+    def test_C1T_10_generates_route_from_MOM_timing(self):
         # The C1T CMV will generate a route within 3 seconds of receiving an incoming mobility operation message
         time_between_messages = check_message_timing(self.bag_dir, "/incoming_mobility_operation", "/plan")
         self.assertTrue(np.all(time_between_messages < 3.0), "Time between messages on /incoming_mobility_operation and /plan exceeded 3 seconds")
 
-    def test_C1T_12_communicate_load_and_unload(self):
+    def test_C1T_13_communicate_load_and_unload(self):
         # Infrastructure can communicate with the C1T CMV that the container is loaded and unloaded
         self.assertTrue(check_port_drayage_ack(self.bag_dir, "PICKUP"), "Vehicle did not ack PICKUP correctly")
         self.assertTrue(check_port_drayage_ack(self.bag_dir, "DROPOFF"), "Vehicle did not ack DROPOFF correctly")
 
-    def test_C1T_13_communicate_checkpoint(self):
+    def test_C1T_14_communicate_checkpoint(self):
         # Infrastructure can communicate with the C1T CMV that the container is loaded and unloaded
         self.assertTrue(check_port_drayage_ack(self.bag_dir, "PORT_CHECKPOINT"), "Vehicle did not ack PORT_CHECKPOINT")
 
-    def test_C1T_16_communicate_inspection(self):
+    def test_C1T_17_communicate_inspection(self):
         # Infrastructure can communicate with the C1T CMV that the container is inspected
         self.assertTrue(check_port_drayage_ack(self.bag_dir, "HOLDING_AREA"), "Vehicle did not ack HOLDING_AREA corectly")
     


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description

<!--- Describe your changes in detail -->
This PR reorders the metrics used for C1T verification testing to match what was finalized in the verification test plan. Additionally, there is a small fix that enables calculating the difference between destinations provided through Rviz and the arrival locations reported by the vehicle.

## Related GitHub Issue

## Related Jira Key

## Motivation and Context

Having the metrics in order makes data analysis more organized, and the fix for Rviz goals is needed to correctly calculate one of the metrics.

## How Has This Been Tested?

Tested on a bag collected from the turtlebot simulator.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
