### PR TITLE
ARC-405 Workzone Analytics Script Code Coverage

### DIFF
--- a/.sonarqube/sonar-project.properties
+++ b/.sonarqube/sonar-project.properties
@@ -12,6 +12,5 @@ src/carma-platform/run_all_control_analysis.py, \
 src/carma-platform/environment_scripts.py, \
 src/carma-platform/carma_system_resource_usage_plot.py, \
 src/carma-platform/run_all_workzone_analysis.py, \
-src/carma-platform/message_scripts.py, \
 src/carma-platform/run_all_regression_analysis.py
 src/carma-platform/utils.py

--- a/src/carma-platform/test/test_guidance_scripts.py
+++ b/src/carma-platform/test/test_guidance_scripts.py
@@ -765,7 +765,7 @@ def test_get_lateral_velocities(mock_mcap_path):
         orientation_timestamps = np.array([0.0, 1.0, 2.0, 3.0, 4.0])
         
         # Test Scenario where vehicle starts straight, lane changes left (30 degrees), moves straight, lane changes right (30 degrees), moves straight at a constant 2 m/s
-        # 30 Degrees -> z = sin(30deg) = 0.259, w = cos(30deg) = 0.966
+        # 30 Degrees -> z = sin(30deg / 2) = 0.259, w = cos(30deg / 2) = 0.966
         orientations = [
             SimpleNamespace(x=0, y=0, z=0, w=1),
             SimpleNamespace(x=0, y=0, z=0.259, w=0.966),

--- a/src/carma-platform/test/test_guidance_scripts.py
+++ b/src/carma-platform/test/test_guidance_scripts.py
@@ -3,6 +3,7 @@ from pathlib import Path
 from unittest.mock import patch, MagicMock
 from guidance_scripts import *
 from pytest import approx
+from types import SimpleNamespace
 import numpy as np
 
 """
@@ -702,3 +703,515 @@ def test_run_speed_limit_change_response_analysis_fail_case(mock_figure):
 
         # Test should fail
         assert passed == False
+
+def test_get_lateral_velocities(mock_mcap_path):
+    """Test Get Lateral Velocities functionality"""
+    with patch('guidance_scripts.extract_mcap_data') as mock_extract:
+        start_time=0
+        end_time=4
+        orientation_timestamps = np.array([0.0, 1.0, 2.0, 3.0, 4.0])
+        orientations = [
+            SimpleNamespace(x=0, y=0, z=0, w=1),
+            SimpleNamespace(x=0, y=0, z=0.09, w=1),
+            SimpleNamespace(x=0.13, y=0, z=0, w=0.99),
+            SimpleNamespace(x=0.17, y=-0.09, z=0, w=0.98),
+            SimpleNamespace(x=0.12, y=0.12, z=0.17, w=0.97)
+        ]
+        twist_timestamps = np.array([0.0, 1.0, 2.0, 3.0, 4.5])
+        twists = [
+            SimpleNamespace(x=1, y=0, z=0),
+            SimpleNamespace(x=2, y=0, z=0),
+            SimpleNamespace(x=1.8, y=0, z=0),
+            SimpleNamespace(x=1.9, y=0, z=0),
+            SimpleNamespace(x=2.1, y=0, z=0)
+        ]
+
+        mock_extract.return_value = {
+            '/localization/current_pose': (orientation_timestamps, orientations),
+            '/hardware_interface/vehicle/twist': (twist_timestamps, twists)
+        }
+
+        lane_change_velocities = get_lateral_velocities(mock_mcap_path, start_time, end_time)
+
+        assert len(lane_change_velocities) == 5
+        assert lane_change_velocities[0][1] == lane_change_velocities[2][1] == 0
+        assert lane_change_velocities[1][1] > 0 and lane_change_velocities[4][1] > 0
+        assert lane_change_velocities[3][1] < 0
+
+    """Test get lateral velocities with no orientation data"""
+    with patch('guidance_scripts.extract_mcap_data') as mock_extract:
+        start_time=0
+        end_time=4
+        orientation_timestamps = np.array([])
+        orientations = []
+        twist_timestamps = np.array([0.0, 1.0, 2.0, 3.0, 4.5])
+        twists = [
+            SimpleNamespace(x=1, y=0, z=0),
+            SimpleNamespace(x=2, y=0, z=0),
+            SimpleNamespace(x=1.8, y=0, z=0),
+            SimpleNamespace(x=1.9, y=0, z=0),
+            SimpleNamespace(x=2.1, y=0, z=0)
+        ]
+
+        mock_extract.return_value = {
+            '/localization/current_pose': (orientation_timestamps, orientations),
+            '/hardware_interface/vehicle/twist': (twist_timestamps, twists)
+        }
+
+        lane_change_velocities = get_lateral_velocities(mock_mcap_path, start_time, end_time)
+
+        assert not lane_change_velocities
+
+
+def test_check_reroute_duration(mock_mcap_path):
+    fake_save_dir = '/fake/dir'
+    max_route_update_duration = 3
+
+    """Test successful check_reroute_duration() with no restricted lanes"""
+
+    with patch('guidance_scripts.extract_mcap_data') as mock_extract, \
+        patch.object(Path, "mkdir") as mock_mkdir, \
+        patch("numpy.savez") as mock_savez:
+
+        mock_extract.return_value = {
+            "/message/incoming_geofence_control": (
+                [1, 2],
+                [
+                    SimpleNamespace(
+                        params=SimpleNamespace(
+                            detail=SimpleNamespace(
+                                choice=5
+                            ),
+                            vclasses=[
+                                SimpleNamespace(**{"vehicle_class": 5})
+                            ]
+                        )
+                    ),
+                    SimpleNamespace(
+                        params=SimpleNamespace(
+                            detail=SimpleNamespace(
+                                choice=5
+                            ),
+                            vclasses=[
+                                SimpleNamespace(**{"vehicle_class": 0})
+                            ]
+                        )
+                    )
+                ]
+            ),
+            "/guidance/route": (
+                [0, 3, 4],
+                [[123,432,632], [123, 342, 241, 632], [123, 342, 142, 143, 632]]
+            )
+        }
+
+        passed = check_reroute_duration(mock_mcap_path, max_route_update_duration, fake_save_dir)
+        assert passed
+
+
+        """Test passing check_reroute_duration() with restricted lane received before closed lane"""
+        mock_extract.return_value = {
+            "/message/incoming_geofence_control": (
+                [1, 2],
+                [
+                    SimpleNamespace(
+                        params=SimpleNamespace(
+                            detail=SimpleNamespace(
+                                choice=5
+                            ),
+                            vclasses=[
+                                SimpleNamespace(**{"vehicle_class": 2})
+                            ]
+                        )
+                    ),
+                    SimpleNamespace(
+                        params=SimpleNamespace(
+                            detail=SimpleNamespace(
+                                choice=5
+                            ),
+                            vclasses=[
+                                SimpleNamespace(**{"vehicle_class": 5})
+                            ]
+                        )
+                    )
+                ]
+            ),
+            "/guidance/route": (
+                [0, 3, 4],
+                [[123,432,632], [123, 342, 241, 632], [123, 342, 142, 143, 632]]
+            )
+        }
+
+        passed = check_reroute_duration(mock_mcap_path, max_route_update_duration, fake_save_dir)
+        assert passed
+
+        """Test passing check_reroute_duration() with restricted lane received after closed lane"""
+        mock_extract.return_value = {
+            "/message/incoming_geofence_control": (
+                [1, 2],
+                [
+                    SimpleNamespace(
+                        params=SimpleNamespace(
+                            detail=SimpleNamespace(
+                                choice=5
+                            ),
+                            vclasses=[
+                                SimpleNamespace(**{"vehicle_class": 5})
+                            ]
+                        )
+                    ),
+                    SimpleNamespace(
+                        params=SimpleNamespace(
+                            detail=SimpleNamespace(
+                                choice=5
+                            ),
+                            vclasses=[
+                                SimpleNamespace(**{"vehicle_class": 2})
+                            ]
+                        )
+                    )
+                ]
+            ),
+            "/guidance/route": (
+                [0, 3, 4],
+                [[123,432,632], [123, 342, 241, 632], [123, 342, 142, 143, 632]]
+            )
+        }
+
+        passed = check_reroute_duration(mock_mcap_path, max_route_update_duration, fake_save_dir)
+        assert passed
+
+        """Test failing check_reroute_duration() with restricted lane update after max_duration"""
+        mock_extract.return_value = {
+            "/message/incoming_geofence_control": (
+                [1, 4],
+                [
+                    SimpleNamespace(
+                        params=SimpleNamespace(
+                            detail=SimpleNamespace(
+                                choice=5
+                            ),
+                            vclasses=[
+                                SimpleNamespace(**{"vehicle_class": 2})
+                            ]
+                        )
+                    ),
+                    SimpleNamespace(
+                        params=SimpleNamespace(
+                            detail=SimpleNamespace(
+                                choice=5
+                            ),
+                            vclasses=[
+                                SimpleNamespace(**{"vehicle_class": 5})
+                            ]
+                        )
+                    )
+                ]
+            ),
+            "/guidance/route": (
+                [0, 5, 6],
+                [[123,432,632], [123, 342, 241, 632], [123, 342, 142, 143, 632]]
+            )
+        }
+
+        passed = check_reroute_duration(mock_mcap_path, max_route_update_duration, fake_save_dir)
+        assert not passed
+
+        """Test failing check_reroute_duration() with closed lane update after max_duration"""
+        mock_extract.return_value = {
+            "/message/incoming_geofence_control": (
+                [1, 2],
+                [
+                    SimpleNamespace(
+                        params=SimpleNamespace(
+                            detail=SimpleNamespace(
+                                choice=5
+                            ),
+                            vclasses=[
+                                SimpleNamespace(**{"vehicle_class": 2})
+                            ]
+                        )
+                    ),
+                    SimpleNamespace(
+                        params=SimpleNamespace(
+                            detail=SimpleNamespace(
+                                choice=5
+                            ),
+                            vclasses=[
+                                SimpleNamespace(**{"vehicle_class": 5})
+                            ]
+                        )
+                    )
+                ]
+            ),
+            "/guidance/route": (
+                [0, 3, 6],
+                [[123,432,632], [123, 342, 241, 632], [123, 342, 142, 143, 632]]
+            )
+        }
+
+        passed = check_reroute_duration(mock_mcap_path, max_route_update_duration, fake_save_dir)
+        assert not passed
+
+        """Test failing check_reroute_duration() with invalid number of route updates"""
+        mock_extract.return_value = {
+            "/message/incoming_geofence_control": (
+                [1, 4],
+                [
+                    SimpleNamespace(
+                        params=SimpleNamespace(
+                            detail=SimpleNamespace(
+                                choice=5
+                            ),
+                            vclasses=[
+                                SimpleNamespace(**{"vehicle_class": 2})
+                            ]
+                        )
+                    ),
+                    SimpleNamespace(
+                        params=SimpleNamespace(
+                            detail=SimpleNamespace(
+                                choice=5
+                            ),
+                            vclasses=[
+                                SimpleNamespace(**{"vehicle_class": 5})
+                            ]
+                        )
+                    )
+                ]
+            ),
+            "/guidance/route": (
+                [0],
+                [[123,432,632]]
+            )
+        }
+
+        passed = check_reroute_duration(mock_mcap_path, max_route_update_duration, fake_save_dir)
+        assert not passed
+
+
+def test_check_speed_limits_in_geofence(mock_mcap_path):
+    fake_save_dir = "/fake/dir"
+    time_enter = 1
+    time_exit = 5
+    advisory_speed = 2
+
+    """Test passing check_speed_limits_in_geofence"""
+
+    with patch("guidance_scripts.extract_mcap_data") as mock_extract, \
+        patch.object(Path, "mkdir") as mock_mkdir, \
+        patch("numpy.savez") as mock_savez:
+
+        mock_extract.side_effect = [
+            # Incoming_geofence_control - Guidance_route_state
+            {"/message/incoming_geofence_control": (
+                [2,4],
+                [
+                    SimpleNamespace(
+                        params=SimpleNamespace(
+                            detail=SimpleNamespace(
+                                choice=12,
+                                maxspeed=2
+                            )
+                        )
+                    )
+                ]
+            )},
+            {"/guidance/route_state": (
+                [3,4],
+                [(2,2),(1.98,3)]
+            )}
+        ]
+
+        passed = check_speed_limits_in_geofence(mock_mcap_path, time_enter, time_exit, advisory_speed, fake_save_dir)
+    
+        assert passed
+
+        """Test failing check_speed_limits_in_geofence() with advisory speed not matched"""
+        mock_extract.side_effect = [
+            # Incoming_geofence_control - Guidance_route_state
+            {"/message/incoming_geofence_control": (
+                [2,4],
+                [
+                    SimpleNamespace(
+                        params=SimpleNamespace(
+                            detail=SimpleNamespace(
+                                choice=12,
+                                maxspeed=2
+                            )
+                        )
+                    )
+                ]
+            )},
+            {"/guidance/route_state": (
+                [3,4],
+                [(2,2),(3,3)]
+            )}
+        ]
+
+        passed = check_speed_limits_in_geofence(mock_mcap_path, time_enter, time_exit, advisory_speed, fake_save_dir)
+    
+        assert not passed
+
+        """Test failing check_speed_limits_in_geofence() with no time enter/exit geofence"""
+        mock_extract.side_effect = [
+            # Incoming_geofence_control - Guidance_route_state
+            {"/message/incoming_geofence_control": (
+                [2,4],
+                [
+                    SimpleNamespace(
+                        params=SimpleNamespace(
+                            detail=SimpleNamespace(
+                                choice=12,
+                                maxspeed=2
+                            )
+                        )
+                    )
+                ]
+            )},
+            {"/guidance/route_state": (
+                [3,4],
+                [(2,2),(3,3)]
+            )}
+        ]
+
+        passed = check_speed_limits_in_geofence(mock_mcap_path, None, None, advisory_speed, fake_save_dir)
+    
+        assert not passed
+
+
+def test_check_geofence_in_reroute(mock_mcap_path):
+    fake_save_dir = "/fake/dir"
+    closed_lanelets = [3,5]
+
+    """Test check_geofence_in_reroute() with closed lanelets in initial route and removed from reroute"""
+    with patch("guidance_scripts.extract_mcap_data") as mock_extract, \
+        patch.object(Path, "mkdir") as mock_mkdir, \
+        patch("numpy.savez") as mock_savez:
+
+        mock_extract.return_value = {
+            "/guidance/route": (
+                [1,2],
+                [[1,3,5,7],[1,2,4,6,7]]
+            )
+        }
+
+        fwz_1_passed, fwz_8_passed = check_geofence_in_reroute(mock_mcap_path, closed_lanelets, fake_save_dir)
+        assert fwz_1_passed
+        assert fwz_8_passed
+
+        """Test check_geofence_in_reroute() with closed lanelets not in initial route and removed from reroute"""
+        mock_extract.return_value = {
+            "/guidance/route": (
+                [1,2],
+                [[1,2,4,6,7],[1,2,6,7]]
+            )
+        }
+
+        fwz_1_passed, fwz_8_passed = check_geofence_in_reroute(mock_mcap_path, closed_lanelets, fake_save_dir)
+        assert not fwz_1_passed
+        assert fwz_8_passed
+
+        """Test check_geofence_in_reroute() with closed lanelets in initial route and in reroute"""
+        mock_extract.return_value = {
+            "/guidance/route": (
+                [1,2],
+                [[1,3,5,7],[1,3,5,6,7]]
+            )
+        }
+
+        fwz_1_passed, fwz_8_passed = check_geofence_in_reroute(mock_mcap_path, closed_lanelets, fake_save_dir)
+        assert fwz_1_passed
+        assert not fwz_8_passed
+
+        """Test check_geofence_in_reroute() with closed lanelets not in initial route and present in reroute"""
+        mock_extract.return_value = {
+            "/guidance/route": (
+                [1,2],
+                [[1,2,4,6,7],[1,3,5,7]]
+            )
+        }
+
+        fwz_1_passed, fwz_8_passed = check_geofence_in_reroute(mock_mcap_path, closed_lanelets, fake_save_dir)
+        assert not fwz_1_passed
+        assert not fwz_8_passed
+
+        """Test check_geofence_in_reroute() with invalid number of routes"""
+        mock_extract.return_value = {
+            "/guidance/route": (
+                [1],
+                [[1,3,5,7]]
+            )
+        }
+
+        fwz_1_passed, fwz_8_passed = check_geofence_in_reroute(mock_mcap_path, closed_lanelets, fake_save_dir)
+        assert not fwz_1_passed
+        assert not fwz_8_passed
+
+        """Test check_geofence_in_reroute() with no closed lanelets"""
+        mock_extract.return_value = {
+            "/guidance/route": (
+                [1,2],
+                [[1,3,5,7],[1,2,4,6,7]]
+            )
+        }
+
+        fwz_1_passed, fwz_8_passed = check_geofence_in_reroute(mock_mcap_path, [], fake_save_dir)
+        assert not fwz_1_passed
+        assert not fwz_8_passed
+
+
+def test_get_route_original_speed(mock_mcap_path):
+
+    with patch('guidance_scripts.extract_mcap_data') as mock_extract:
+
+        mock_extract.return_value = {
+            '/guidance/route_state': (
+                [1,3,5],
+                [2,4,6]
+            )
+        }
+
+        speed_limit = get_route_original_speed(mock_mcap_path)
+        assert speed_limit == 2
+
+        mock_extract.return_value = {
+            '/guidance/route_state': (
+                [1,3,5],
+                [6,4,2]
+            )
+        }
+
+        speed_limit = get_route_original_speed(mock_mcap_path)
+        assert speed_limit == 6
+
+
+def test_get_geofence_entrance_and_exit_times(mock_mcap_path):
+
+    """Test get_geofence_entrance_and_exit_times() with normal behavior"""
+    with patch('guidance_scripts.extract_mcap_data') as mock_extract:
+
+        mock_extract.return_value = {
+            '/environment/active_geofence': (
+                [1,2,3,4,5,6],
+                [False, False, True, True, True, False]
+            )
+        }
+
+        time_enter, time_exit, found = get_geofence_entrance_and_exit_times(mock_mcap_path)
+        assert time_enter == 3
+        assert time_exit == 6
+        assert found
+
+        """Test get_geofence_entrance_and_exit_times() with never entering geofence"""
+        mock_extract.return_value = {
+            '/environment/active_geofence': (
+                [1,2,3,4,5,6],
+                [False, False, False, False, False, False]
+            )
+        }
+
+        time_enter, time_exit, found = get_geofence_entrance_and_exit_times(mock_mcap_path)
+        assert time_enter == None
+        assert time_exit == None
+        assert not found

--- a/src/carma-platform/test/test_guidance_scripts.py
+++ b/src/carma-platform/test/test_guidance_scripts.py
@@ -763,20 +763,23 @@ def test_get_lateral_velocities(mock_mcap_path):
         start_time=0
         end_time=4
         orientation_timestamps = np.array([0.0, 1.0, 2.0, 3.0, 4.0])
+        
+        # Test Scenario where vehicle starts straight, lane changes left (30 degrees), moves straight, lane changes right (30 degrees), moves straight at a constant 2 m/s
+        # 30 Degrees -> z = sin(30deg) = 0.259, w = cos(30deg) = 0.966
         orientations = [
             SimpleNamespace(x=0, y=0, z=0, w=1),
-            SimpleNamespace(x=0, y=0, z=0.09, w=1),
-            SimpleNamespace(x=0.13, y=0, z=0, w=0.99),
-            SimpleNamespace(x=0.17, y=-0.09, z=0, w=0.98),
-            SimpleNamespace(x=0.12, y=0.12, z=0.17, w=0.97)
+            SimpleNamespace(x=0, y=0, z=0.259, w=0.966),
+            SimpleNamespace(x=0, y=0, z=0, w=1),
+            SimpleNamespace(x=0, y=0, z=-0.259, w=0.966),
+            SimpleNamespace(x=0, y=0, z=0, w=1)
         ]
         twist_timestamps = np.array([0.0, 1.0, 2.0, 3.0, 4.5])
         twists = [
-            SimpleNamespace(x=1, y=0, z=0),
             SimpleNamespace(x=2, y=0, z=0),
-            SimpleNamespace(x=1.8, y=0, z=0),
-            SimpleNamespace(x=1.9, y=0, z=0),
-            SimpleNamespace(x=2.1, y=0, z=0)
+            SimpleNamespace(x=2, y=0, z=0),
+            SimpleNamespace(x=2, y=0, z=0),
+            SimpleNamespace(x=2, y=0, z=0),
+            SimpleNamespace(x=2, y=0, z=0)
         ]
 
         mock_extract.return_value = {
@@ -787,9 +790,9 @@ def test_get_lateral_velocities(mock_mcap_path):
         lane_change_velocities = get_lateral_velocities(mock_mcap_path, start_time, end_time)
 
         assert len(lane_change_velocities) == 5
-        assert lane_change_velocities[0][1] == lane_change_velocities[2][1] == 0
-        assert lane_change_velocities[1][1] > 0 and lane_change_velocities[4][1] > 0
-        assert lane_change_velocities[3][1] < 0
+        assert lane_change_velocities[0][1] == lane_change_velocities[2][1] == lane_change_velocities[4][1] == 0
+        assert lane_change_velocities[1][1] == approx(1.0, rel=1e-2)
+        assert lane_change_velocities[3][1] == approx(-1.0, rel=1e-2)
 
     """Test get lateral velocities with no orientation data"""
     with patch('guidance_scripts.extract_mcap_data') as mock_extract:

--- a/src/carma-platform/test/test_guidance_scripts.py
+++ b/src/carma-platform/test/test_guidance_scripts.py
@@ -1,6 +1,6 @@
 import pytest
 from pathlib import Path
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch, MagicMock, mock_open
 from guidance_scripts import *
 from pytest import approx
 from types import SimpleNamespace
@@ -35,11 +35,14 @@ def test_get_engage_time(mock_mcap_path):
         assert start_time == 2
         assert end_time == 4
 
+@patch('matplotlib.pyplot.figure')
+@patch('builtins.open', new_callable=mock_open)
+@patch('guidance_scripts.Path.mkdir')
+@patch('numpy.savez')
+@patch('json.dump')
+def test_run_crosstrack_analysis(mock_json_dump, mock_file, mock_savez, mock_mkdir, mock_plt, mock_mcap_path):
+    with patch("guidance_scripts.extract_mcap_data") as mock_extract:
 
-def test_run_crosstrack_analysis(mock_mcap_path):
-    with patch("guidance_scripts.extract_mcap_data") as mock_extract, patch(
-        "guidance_scripts.plt"
-    ) as mock_plt:
         mock_extract.return_value = {
             "/guidance/route_state": (
                 [0, 1, 2, 3],
@@ -48,15 +51,17 @@ def test_run_crosstrack_analysis(mock_mcap_path):
         }
         mock_plt.figure.return_value = MagicMock()
 
+        fake_save_dir = "/fake/dir"
+
         is_passed, stats, plot_figure, cross_tracks, timestamps = (
             run_crosstrack_analysis(
                 mock_mcap_path,
                 error_threshold_to_pass_meter=2.0,
                 start_time=0,
                 end_time=3,
-                save_stats_dir=None,
-                save_data_dir=None,
-                save_plot_dir=None,
+                save_stats_dir=fake_save_dir,
+                save_data_dir=fake_save_dir,
+                save_plot_dir=fake_save_dir,
             )
         )
 
@@ -68,11 +73,14 @@ def test_run_crosstrack_analysis(mock_mcap_path):
         assert cross_tracks == approx([1.0, 1.5, 0.5, 1.8])
         assert timestamps == approx([0, 1, 2, 3])
 
+@patch('matplotlib.pyplot.figure')
+@patch('builtins.open', new_callable=mock_open)
+@patch('guidance_scripts.Path.mkdir')
+@patch('numpy.savez')
+@patch('json.dump')
+def test_run_turn_accuracy_analysis(mock_json_dump, mock_file, mock_savez, mock_mkdir, mock_plt, mock_mcap_path):
+    with patch("guidance_scripts.extract_mcap_data") as mock_extract:
 
-def test_run_turn_accuracy_analysis(mock_mcap_path):
-    with patch("guidance_scripts.extract_mcap_data") as mock_extract, patch(
-        "guidance_scripts.plt"
-    ) as mock_plt:
         mock_extract.return_value = {
             "/localization/current_pose": (
                 [0, 1, 2],
@@ -81,6 +89,7 @@ def test_run_turn_accuracy_analysis(mock_mcap_path):
             "/guidance/plan_trajectory": ([0], [[(0.0, 0.0), (1.0, 1.0), (2.0, 2.0)]]),
         }
         mock_plt.figure.return_value = MagicMock()
+        fake_save_dir = "/fake/dir"
 
         (
             is_passed,
@@ -95,6 +104,9 @@ def test_run_turn_accuracy_analysis(mock_mcap_path):
             error_threshold_to_pass_meter=2.0,
             start_time=0,
             end_time=2,
+            save_stats_dir=Path(fake_save_dir),
+            save_data_dir=fake_save_dir,
+            save_plot_dir=fake_save_dir
         )
 
         expected_actual_path = [[0.0, 0.0], [1.0, 1.0], [2.0, 2.0]]
@@ -143,16 +155,21 @@ def test_calculate_window_average():
     # Timestamps should start from original timestamps
     assert avg_timestamps[0] == approx(0.0)
 
-
-def test_run_acceleration_comfort_analysis(mock_mcap_path):
-    with patch("guidance_scripts.extract_mcap_data") as mock_extract, patch(
-        "guidance_scripts.plt"
-    ) as mock_plt:
+@patch('guidance_scripts.plt')
+@patch('builtins.open', new_callable=mock_open)
+@patch('guidance_scripts.Path.mkdir')
+@patch('numpy.savez')
+@patch('json.dump')
+def test_run_acceleration_comfort_analysis(mock_json_dump, mock_file, mock_savez, mock_mkdir, mock_plt, mock_mcap_path):
+    with patch("guidance_scripts.extract_mcap_data") as mock_extract:
         # Mock plt.subplots to return a tuple of (figure, (ax1, ax2))
         mock_fig = MagicMock()
         mock_ax1 = MagicMock()
         mock_ax2 = MagicMock()
         mock_plt.subplots.return_value = (mock_fig, (mock_ax1, mock_ax2))
+
+        # Create fake save directory
+        fake_save_dir = "/fake/dir"
 
         # Use more data points with 0.1s intervals to ensure window calculations work
         timestamps = np.arange(0, 3.1, 0.1)  # 0 to 3 seconds with 0.1s intervals
@@ -210,6 +227,9 @@ def test_run_acceleration_comfort_analysis(mock_mcap_path):
             comfort_deceleration_threshold_to_pass=3.0,
             start_time=0,
             end_time=3,
+            save_stats_dir=Path(fake_save_dir),
+            save_data_dir=fake_save_dir,
+            save_plot_dir=fake_save_dir
         )
 
         # Test instant acceleration stats
@@ -275,12 +295,14 @@ def test_calculate_instant_lateral_values_zero_input():
     assert np.all(lateral_acc == 0)
     assert np.all(lateral_jerk == 0)
 
-
-def test_run_lateral_analysis(mock_mcap_path):
+@patch('guidance_scripts.plt')
+@patch('builtins.open', new_callable=mock_open)
+@patch('guidance_scripts.Path.mkdir')
+@patch('numpy.savez')
+@patch('json.dump')
+def test_run_lateral_analysis(mock_json_dump, mock_file, mock_savez, mock_mkdir, mock_plt, mock_mcap_path):
     """Test the run_lateral_analysis function with mocked data"""
-    with patch("guidance_scripts.extract_mcap_data") as mock_extract, patch(
-        "guidance_scripts.plt"
-    ) as mock_plt:
+    with patch("guidance_scripts.extract_mcap_data") as mock_extract:
 
         # Mock timestamps and twist messages
         timestamps = np.array([0.0, 0.5, 1.0, 1.5, 2.0])
@@ -309,6 +331,9 @@ def test_run_lateral_analysis(mock_mcap_path):
             (mock_fig_jerk, (mock_ax3, mock_ax4)),
         ]
 
+        # Create fake save directory
+        fake_save_dir = "/fake/dir"
+
         # Run analysis
         (
             is_passed,
@@ -323,7 +348,12 @@ def test_run_lateral_analysis(mock_mcap_path):
             lateral_jerk_avg,
             timestamps_out,
         ) = run_lateral_analysis(
-            mock_mcap_path, acc_threshold_to_pass=2.0, jerk_threshold_to_pass=2.0
+            mock_mcap_path, 
+            acc_threshold_to_pass=2.0, 
+            jerk_threshold_to_pass=2.0,
+            save_stats_dir=Path(fake_save_dir),
+            save_data_dir=Path(fake_save_dir),
+            save_plot_dir=Path(fake_save_dir)
         )
 
         # Test that values were calculated correctly
@@ -380,11 +410,13 @@ def test_run_lateral_analysis_exceeds_threshold(mock_mcap_path):
         # Test that analysis failed due to exceeded thresholds
         assert result[0] == False  # is_passed should be False
 
-
-def test_run_guidance_steering_analysis(mock_mcap_path):
-    with patch("guidance_scripts.extract_mcap_data") as mock_extract, patch(
-        "guidance_scripts.plt"
-    ) as mock_plt:
+@patch('guidance_scripts.plt')
+@patch('builtins.open', new_callable=mock_open)
+@patch('guidance_scripts.Path.mkdir')
+@patch('numpy.savez')
+@patch('json.dump')
+def test_run_guidance_steering_analysis(mock_json_dump, mock_file, mock_savez, mock_mkdir, mock_plt, mock_mcap_path):
+    with patch("guidance_scripts.extract_mcap_data") as mock_extract:
 
         # Mock timestamps and steering angles
         timestamps = np.array([0, 1, 2, 3, 4])
@@ -399,6 +431,9 @@ def test_run_guidance_steering_analysis(mock_mcap_path):
         # Mock plt.figure to return a MagicMock
         mock_plt.figure.return_value = MagicMock()
 
+        # Create fake save directory
+        fake_save_dir = "/fake/dir"
+
         # Run analysis
         is_passed, stats, plot_figure, error_angles, common_timestamps = (
             run_guidance_steering_analysis(
@@ -406,6 +441,9 @@ def test_run_guidance_steering_analysis(mock_mcap_path):
                 error_threshold_to_pass_radian=0.1,
                 start_time=0,
                 end_time=4,
+                save_stats_dir=Path(fake_save_dir),
+                save_data_dir=Path(fake_save_dir),
+                save_plot_dir=Path(fake_save_dir)
             )
         )
 
@@ -448,11 +486,13 @@ def test_run_guidance_steering_analysis_fails_threshold(mock_mcap_path):
         assert is_passed == False  # Should fail due to large errors
         assert stats["median"] > 0.1  # Median error should exceed threshold
 
-
-def test_run_steering_wheel_analysis(mock_mcap_path):
-    with patch("guidance_scripts.extract_mcap_data") as mock_extract, patch(
-        "guidance_scripts.plt"
-    ) as mock_plt:
+@patch('guidance_scripts.plt')
+@patch('builtins.open', new_callable=mock_open)
+@patch('guidance_scripts.Path.mkdir')
+@patch('numpy.savez')
+@patch('json.dump')
+def test_run_steering_wheel_analysis(mock_json_dump, mock_file, mock_savez, mock_mkdir, mock_plt, mock_mcap_path):
+    with patch("guidance_scripts.extract_mcap_data") as mock_extract:
 
         # Mock timestamps and steering values
         timestamps = np.array([0, 1, 2, 3, 4])
@@ -467,10 +507,18 @@ def test_run_steering_wheel_analysis(mock_mcap_path):
 
         mock_plt.figure.return_value = MagicMock()
 
+        # Create fake save directory
+        fake_save_dir = "/fake/dir"
+
         # Run analysis
         is_passed, stats, plot_figure, error_values, timestamps = (
             run_steering_wheel_analysis(
-                mock_mcap_path, error_threshold_to_pass=0.1, start_time=0, end_time=4
+                mock_mcap_path, error_threshold_to_pass=0.1,
+                start_time=0, 
+                end_time=4,
+                save_stats_dir=Path(fake_save_dir),
+                save_data_dir=Path(fake_save_dir),
+                save_plot_dir=Path(fake_save_dir)
             )
         )
 
@@ -626,9 +674,11 @@ def test_analyze_speed_responses():
 
 
 @patch('matplotlib.pyplot.figure')
+@patch('builtins.open', new_callable=mock_open)
+@patch('guidance_scripts.Path.mkdir')
 @patch('numpy.savez')
 @patch('json.dump')
-def test_run_speed_limit_change_response_analysis_basic(mock_json_dump, mock_savez, mock_figure):
+def test_run_speed_limit_change_response_analysis_basic(mock_json_dump, mock_savez, mock_mkdir, mock_file, mock_figure):
     """Test the main analysis function with basic mocked data"""
     with patch('guidance_scripts.extract_mcap_data') as mock_extract:
         # Create simple test data
@@ -648,15 +698,18 @@ def test_run_speed_limit_change_response_analysis_basic(mock_json_dump, mock_sav
         mock_fig = MagicMock()
         mock_figure.return_value = mock_fig
 
+        # Create fake save directory
+        fake_save_dir = "/fake/dir"
+
         # Run the analysis function
         result = run_speed_limit_change_response_analysis(
             mcap_path="test.mcap",
             response_time_threshold=0.2,
             steady_state_indication_time=1.0,
             speed_tolerance_pct=0.05,
-            save_stats_dir=None,
-            save_data_dir=None,
-            save_plot_dir=None
+            save_stats_dir=fake_save_dir,
+            save_data_dir=fake_save_dir,
+            save_plot_dir=fake_save_dir
         )
 
         # Check basic structure of results
@@ -763,15 +816,15 @@ def test_get_lateral_velocities(mock_mcap_path):
         assert not lane_change_velocities
 
 
-def test_check_reroute_duration(mock_mcap_path):
+@patch('guidance_scripts.Path.mkdir')
+@patch('numpy.savez')
+def test_check_reroute_duration(mock_savez, mock_mkdir, mock_mcap_path):
     fake_save_dir = '/fake/dir'
     max_route_update_duration = 3
 
     """Test successful check_reroute_duration() with no restricted lanes"""
 
-    with patch('guidance_scripts.extract_mcap_data') as mock_extract, \
-        patch.object(Path, "mkdir") as mock_mkdir, \
-        patch("numpy.savez") as mock_savez:
+    with patch('guidance_scripts.extract_mcap_data') as mock_extract:
 
         mock_extract.return_value = {
             "/message/incoming_geofence_control": (
@@ -990,7 +1043,9 @@ def test_check_reroute_duration(mock_mcap_path):
         assert not passed
 
 
-def test_check_speed_limits_in_geofence(mock_mcap_path):
+@patch('guidance_scripts.Path.mkdir')
+@patch('numpy.savez')
+def test_check_speed_limits_in_geofence(mock_savez, mock_mkdir, mock_mcap_path):
     fake_save_dir = "/fake/dir"
     time_enter = 1
     time_exit = 5
@@ -998,9 +1053,7 @@ def test_check_speed_limits_in_geofence(mock_mcap_path):
 
     """Test passing check_speed_limits_in_geofence"""
 
-    with patch("guidance_scripts.extract_mcap_data") as mock_extract, \
-        patch.object(Path, "mkdir") as mock_mkdir, \
-        patch("numpy.savez") as mock_savez:
+    with patch("guidance_scripts.extract_mcap_data") as mock_extract:
 
         mock_extract.side_effect = [
             # Incoming_geofence_control - Guidance_route_state
@@ -1080,14 +1133,14 @@ def test_check_speed_limits_in_geofence(mock_mcap_path):
         assert not passed
 
 
-def test_check_geofence_in_reroute(mock_mcap_path):
+@patch('guidance_scripts.Path.mkdir')
+@patch('numpy.savez')
+def test_check_geofence_in_reroute(mock_savez, mock_mkdir, mock_mcap_path):
     fake_save_dir = "/fake/dir"
     closed_lanelets = [3,5]
 
     """Test check_geofence_in_reroute() with closed lanelets in initial route and removed from reroute"""
-    with patch("guidance_scripts.extract_mcap_data") as mock_extract, \
-        patch.object(Path, "mkdir") as mock_mkdir, \
-        patch("numpy.savez") as mock_savez:
+    with patch("guidance_scripts.extract_mcap_data") as mock_extract:
 
         mock_extract.return_value = {
             "/guidance/route": (

--- a/src/carma-platform/test/test_message_scripts.py
+++ b/src/carma-platform/test/test_message_scripts.py
@@ -16,7 +16,12 @@ python3 -m pytest test
 def mock_mcap_path():
     return Path("/path/to/mock.mcap")
 
-def test_passing_check_tcm_acknowledgement_delay(mock_mcap_path):
+@patch('message_scripts.plt')
+@patch('builtins.open', new_callable=mock_open)
+@patch('message_scripts.Path.mkdir')
+@patch('numpy.savez')
+@patch('json.dump')
+def test_passing_check_tcm_acknowledgement_delay(mock_json_dump, mock_savez, mock_mkdir, mock_file, mock_plt, mock_mcap_path):
     fake_save_dir = '/fake/dir'
     max_delay_sec = 1
     mock_data = {
@@ -64,12 +69,7 @@ def test_passing_check_tcm_acknowledgement_delay(mock_mcap_path):
         ]
     }
 
-    with patch("message_scripts.extract_mcap_data") as mock_extract, \
-        patch('message_scripts.plt') as mock_plt, \
-        patch.object(Path, "mkdir") as mock_mkdir, \
-        patch("numpy.savez") as mock_savez, \
-        patch("builtins.open", mock_open()) as mock_file, \
-        patch("json.dump") as mock_json_dump:
+    with patch("message_scripts.extract_mcap_data") as mock_extract:
 
         mock_extract.return_value = mock_data
 
@@ -86,8 +86,8 @@ def test_passing_check_tcm_acknowledgement_delay(mock_mcap_path):
         assert stats["maximum"] == approx(0.14, rel=1e-2)
         assert stats["sample_count"] == 3
 
-
-def test_failing_check_tcm_acknowledgement_delay(mock_mcap_path):
+@patch('message_scripts.plt')
+def test_failing_check_tcm_acknowledgement_delay(mock_plt, mock_mcap_path):
     max_delay_sec = 1
     mock_data = {
         '/message/incoming_geofence_control':
@@ -134,8 +134,7 @@ def test_failing_check_tcm_acknowledgement_delay(mock_mcap_path):
         ]
     }
 
-    with patch("message_scripts.extract_mcap_data") as mock_extract, \
-        patch('message_scripts.plt') as mock_plt:
+    with patch("message_scripts.extract_mcap_data") as mock_extract:
 
         mock_extract.return_value = mock_data
 
@@ -152,8 +151,12 @@ def test_failing_check_tcm_acknowledgement_delay(mock_mcap_path):
         assert stats["maximum"] == approx(1.14, rel=1e-2)
         assert stats["sample_count"] == 2
 
-
-def test_passing_check_tcm_response_time(mock_mcap_path):
+@patch('message_scripts.plt')
+@patch('builtins.open', new_callable=mock_open)
+@patch('message_scripts.Path.mkdir')
+@patch('numpy.savez')
+@patch('json.dump')
+def test_passing_check_tcm_response_time(mock_json_dump, mock_savez, mock_mkdir, mock_file, mock_plt, mock_mcap_path):
     fake_save_dir = '/fake/dir'
     expected_duration_sec = 1
 
@@ -205,12 +208,7 @@ def test_passing_check_tcm_response_time(mock_mcap_path):
         ]
     }
 
-    with patch('message_scripts.extract_mcap_data') as mock_extract, \
-        patch('message_scripts.plt') as mock_plt, \
-        patch.object(Path, "mkdir") as mock_mkdir, \
-        patch("numpy.savez") as mock_savez, \
-        patch("builtins.open", mock_open()) as mock_file, \
-        patch("json.dump") as mock_json_dump:
+    with patch('message_scripts.extract_mcap_data') as mock_extract:
 
         mock_extract.return_value = mock_data
 
@@ -222,8 +220,12 @@ def test_passing_check_tcm_response_time(mock_mcap_path):
 
         assert passed
 
-
-def test_failing_check_tcm_response_time(mock_mcap_path):
+@patch('message_scripts.plt')
+@patch('builtins.open', new_callable=mock_open)
+@patch('message_scripts.Path.mkdir')
+@patch('numpy.savez')
+@patch('json.dump')
+def test_failing_check_tcm_response_time(mock_json_dump, mock_savez, mock_mkdir, mock_file, mock_plt, mock_mcap_path):
     fake_save_dir = '/fake/dir'
     expected_duration_sec = 1
 
@@ -275,12 +277,7 @@ def test_failing_check_tcm_response_time(mock_mcap_path):
         ]
     }
 
-    with patch('message_scripts.extract_mcap_data') as mock_extract, \
-        patch('message_scripts.plt') as mock_plt, \
-        patch.object(Path, "mkdir") as mock_mkdir, \
-        patch("numpy.savez") as mock_savez, \
-        patch("builtins.open", mock_open()) as mock_file, \
-        patch("json.dump") as mock_json_dump:
+    with patch('message_scripts.extract_mcap_data') as mock_extract:
 
         mock_extract.return_value = mock_data
 
@@ -292,8 +289,11 @@ def test_failing_check_tcm_response_time(mock_mcap_path):
 
         assert not passed
 
-
-def test_process_cc_logs_for_tcr_tcm_data():
+@patch('message_scripts.plt')
+@patch('message_scripts.Path.mkdir')
+@patch('numpy.savez')
+@patch('json.dump')
+def test_process_cc_logs_for_tcr_tcm_data(mock_json_dump, mock_savez, mock_mkdir, mock_plt):
     log_date = "2025-05-20"
     max_delay_sec = 0.1
     expected_rate_hz = 20
@@ -329,11 +329,7 @@ def test_process_cc_logs_for_tcr_tcm_data():
 
     with patch('os.listdir', return_value=fake_files), \
         patch('os.path.isfile', return_value=True), \
-        patch('builtins.open', mock_open(read_data=file_contents)) as mock_file, \
-        patch('message_scripts.plt') as mock_plt, \
-        patch.object(Path, "mkdir") as mock_mkdir, \
-        patch("numpy.savez") as mock_savez, \
-        patch("json.dump") as mock_json_dump:
+        patch('builtins.open', mock_open(read_data=file_contents)) as mock_file:
 
         mock_fig = MagicMock()
         mock_ax1 = MagicMock()
@@ -366,8 +362,11 @@ def test_process_cc_logs_for_tcr_tcm_data():
                 if tcm_id in inf_rate_tcm_ids:
                     assert tcm_data["rate"] == float('inf')
 
-
-def test_bad_data_process_cc_logs_for_tcr_tcm_data():
+@patch('message_scripts.plt')
+@patch('message_scripts.Path.mkdir')
+@patch('numpy.savez')
+@patch('json.dump')
+def test_bad_data_process_cc_logs_for_tcr_tcm_data(mock_json_dump, mock_savez, mock_mkdir, mock_plt):
     log_date = "2025-05-20"
     max_delay_sec = 0.1
     expected_rate_hz = 0
@@ -405,11 +404,7 @@ def test_bad_data_process_cc_logs_for_tcr_tcm_data():
 
     with patch('os.listdir', return_value=fake_files), \
         patch('os.path.isfile', return_value=True), \
-        patch('builtins.open', mock_open(read_data=file_contents)) as mock_file, \
-        patch('message_scripts.plt') as mock_plt, \
-        patch.object(Path, "mkdir") as mock_mkdir, \
-        patch("numpy.savez") as mock_savez, \
-        patch("json.dump") as mock_json_dump:
+        patch('builtins.open', mock_open(read_data=file_contents)) as mock_file:
 
         mock_fig = MagicMock()
         mock_ax1 = MagicMock()
@@ -439,7 +434,10 @@ def test_bad_data_process_cc_logs_for_tcr_tcm_data():
                 assert tcm_data["rate"] == approx(expected_rate_hz, rel=0.05)
 
 
-def test_passing_check_cc_response_delay():
+@patch('builtins.open', new_callable=mock_open)
+@patch('numpy.savez')
+@patch('json.dump')
+def test_passing_check_cc_response_delay(mock_json_dump, mock_savez, mock_file):
     fake_save_dir = '/fake/dir'
     expected_delay_sec = 1
 
@@ -447,17 +445,17 @@ def test_passing_check_cc_response_delay():
                'B': {'tcr_time': 1.5, 'first_Tcm_time': 2.4, 'response_delay': 0.9, 'b1': {'timestamps': [2.4], 'msgnum': 1, 'count': 1, 'rate': 0}}
     }
 
-    with patch.object(Path, "mkdir") as mock_mkdir, \
-        patch("numpy.savez") as mock_savez, \
-        patch("builtins.open", mock_open()) as mock_file, \
-        patch("json.dump") as mock_json_dump:
+    with patch.object(Path, "mkdir") as mock_mkdir:
     
         passed = check_cc_response_delay(cc_data, expected_delay_sec, fake_save_dir, fake_save_dir)
 
         assert passed
 
 
-def test_failing_check_cc_response_delay():
+@patch('builtins.open', new_callable=mock_open)
+@patch('numpy.savez')
+@patch('json.dump')
+def test_failing_check_cc_response_delay(mock_json_dump, mock_savez, mock_file):
     fake_save_dir = '/fake/dir'
     expected_delay_sec = 1
 
@@ -465,17 +463,17 @@ def test_failing_check_cc_response_delay():
                'B': {'tcr_time': 1.5, 'first_Tcm_time': 2.6, 'response_delay': 1.1, 'b1': {'timestamps': [2.6], 'msgnum': 1, 'count': 1, 'rate': 0}}
     }
 
-    with patch.object(Path, "mkdir") as mock_mkdir, \
-        patch("numpy.savez") as mock_savez, \
-        patch("builtins.open", mock_open()) as mock_file, \
-        patch("json.dump") as mock_json_dump:
+    with patch.object(Path, "mkdir") as mock_mkdir:
     
         passed = check_cc_response_delay(cc_data, expected_delay_sec, fake_save_dir, fake_save_dir)
 
         assert not passed
 
 
-def test_passing_check_tcm_broadcast_count():
+@patch('builtins.open', new_callable=mock_open)
+@patch('numpy.savez')
+@patch('json.dump')
+def test_passing_check_tcm_broadcast_count(mock_json_dump, mock_savez, mock_file):
     fake_save_dir = '/fake/dir'
     expected_count = 3
 
@@ -485,17 +483,17 @@ def test_passing_check_tcm_broadcast_count():
 
     acknowledgements = [('A', 1, 1.1, 1.2), ('B', 2, 2.6, 3.2)]
 
-    with patch.object(Path, "mkdir") as mock_mkdir, \
-        patch("numpy.savez") as mock_savez, \
-        patch("builtins.open", mock_open()) as mock_file, \
-        patch("json.dump") as mock_json_dump:
+    with patch.object(Path, "mkdir") as mock_mkdir:
 
         passed = check_tcm_broadcast_count(cc_data, acknowledgements, expected_count, fake_save_dir, fake_save_dir)
 
         assert passed
 
 
-def test_failing_check_tcm_broadcast_count():
+@patch('builtins.open', new_callable=mock_open)
+@patch('numpy.savez')
+@patch('json.dump')
+def test_failing_check_tcm_broadcast_count(mock_json_dump, mock_savez, mock_file):
     fake_save_dir = '/fake/dir'
     expected_count = 2 # Causes failure on 'A' because the count is greater than expected
 
@@ -505,17 +503,16 @@ def test_failing_check_tcm_broadcast_count():
 
     acknowledgements = [('A', 1, 1.1, 1.2)] # Causes failure on 'B' because count is less than expected AND was not acknowledged
 
-    with patch.object(Path, "mkdir") as mock_mkdir, \
-        patch("numpy.savez") as mock_savez, \
-        patch("builtins.open", mock_open()) as mock_file, \
-        patch("json.dump") as mock_json_dump:
+    with patch.object(Path, "mkdir") as mock_mkdir:
 
         passed = check_tcm_broadcast_count(cc_data, acknowledgements, expected_count, fake_save_dir, fake_save_dir)
 
         assert not passed
 
-
-def test_passing_check_tcm_broadcast_rate():
+@patch('builtins.open', new_callable=mock_open)
+@patch('numpy.savez')
+@patch('json.dump')
+def test_passing_check_tcm_broadcast_rate(mock_json_dump, mock_savez, mock_file):
     fake_save_dir = '/fake/dir'
     expected_rate_hz = 5
 
@@ -525,17 +522,16 @@ def test_passing_check_tcm_broadcast_rate():
 
     acknowledgements = [('A', 1, 1.1, 1.2), ('B', 2, 2.6, 3.2)]
 
-    with patch.object(Path, "mkdir") as mock_mkdir, \
-        patch("numpy.savez") as mock_savez, \
-        patch("builtins.open", mock_open()) as mock_file, \
-        patch("json.dump") as mock_json_dump:
+    with patch.object(Path, "mkdir") as mock_mkdir:
 
         passed = check_tcm_broadcast_rate(cc_data, acknowledgements, expected_rate_hz, fake_save_dir, fake_save_dir)
 
         assert passed
 
-
-def test_failing_check_tcm_broadcast_rate():
+@patch('builtins.open', new_callable=mock_open)
+@patch('numpy.savez')
+@patch('json.dump')
+def test_failing_check_tcm_broadcast_rate(mock_json_dump, mock_savez, mock_file):
     fake_save_dir = '/fake/dir'
     expected_rate_hz = 10 # Fails 'A' for having an incorrect rate (still accepted because acknowledged)
 
@@ -545,10 +541,7 @@ def test_failing_check_tcm_broadcast_rate():
 
     acknowledgements = [('A', 1, 1.1, 1.2)] # Fails 'B' because rate is wrong AND not acknowledged
 
-    with patch.object(Path, "mkdir") as mock_mkdir, \
-        patch("numpy.savez") as mock_savez, \
-        patch("builtins.open", mock_open()) as mock_file, \
-        patch("json.dump") as mock_json_dump:
+    with patch.object(Path, "mkdir") as mock_mkdir:
 
         passed = check_tcm_broadcast_rate(cc_data, acknowledgements, expected_rate_hz, fake_save_dir, fake_save_dir)
 

--- a/src/carma-platform/test/test_message_scripts.py
+++ b/src/carma-platform/test/test_message_scripts.py
@@ -88,7 +88,6 @@ def test_passing_check_tcm_acknowledgement_delay(mock_mcap_path):
 
 
 def test_failing_check_tcm_acknowledgement_delay(mock_mcap_path):
-    fake_save_dir = '/fake/dir'
     max_delay_sec = 1
     mock_data = {
         '/message/incoming_geofence_control':

--- a/src/carma-platform/test/test_message_scripts.py
+++ b/src/carma-platform/test/test_message_scripts.py
@@ -1,0 +1,557 @@
+import pytest
+from pathlib import Path
+from unittest.mock import patch, MagicMock, mock_open
+from message_scripts import *
+from pytest import approx
+from types import SimpleNamespace
+import numpy as np
+
+"""
+Usage:
+cd carma-analytics-fotda/src/carma-platform/
+python3 -m pytest test
+"""
+
+@pytest.fixture
+def mock_mcap_path():
+    return Path("/path/to/mock.mcap")
+
+def test_passing_check_tcm_acknowledgement_delay(mock_mcap_path):
+    fake_save_dir = '/fake/dir'
+    max_delay_sec = 1
+    mock_data = {
+        '/message/incoming_geofence_control':
+        [
+            [142.25, 142.31, 144.76],
+            [
+                SimpleNamespace(
+                    reqid=SimpleNamespace(
+                        id=np.array([246, 136,  69,  62, 167, 197,  69,  17], dtype=np.int64)
+                    ),
+                    msgnum=1
+                ),
+                SimpleNamespace(
+                    reqid=SimpleNamespace(
+                        id=np.array([246, 136,  69,  62, 167, 197,  69,  17], dtype=np.int64)
+                    ),
+                    msgnum=2
+                ),
+                SimpleNamespace(
+                    reqid=SimpleNamespace(
+                        id=np.array([253, 183,   5,  51, 158,  15,  76,  27])
+                    ),
+                    msgnum=1
+                )
+            ]
+        ],
+        '/message/outgoing_mobility_operation':
+        [
+            [142.28, 142.45, 144.77],
+            [
+                SimpleNamespace(
+                    strategy="carma3/Geofence_Acknowledgement",
+                    strategy_params='traffic_control_id:f688453ea7c54511, msgnum:1, acknowledgement:1, reason:Successfully processed TCM.'
+                ),
+                SimpleNamespace(
+                    strategy="carma3/Geofence_Acknowledgement",
+                    strategy_params='traffic_control_id:f688453ea7c54511, msgnum:2, acknowledgement:1, reason:Successfully processed TCM.'
+                ),
+                SimpleNamespace(
+                    strategy="carma3/Geofence_Acknowledgement",
+                    strategy_params='traffic_control_id:fdb705339e0f4c1b, msgnum:1, acknowledgement:1, reason:Dropping received TrafficControl message with already handled id: 008ba29f-41eb-4df1-cf0a-4e3a2ab11096'
+                )
+            ]
+        ]
+    }
+
+    with patch("message_scripts.extract_mcap_data") as mock_extract, \
+        patch('message_scripts.plt') as mock_plt, \
+        patch.object(Path, "mkdir") as mock_mkdir, \
+        patch("numpy.savez") as mock_savez, \
+        patch("builtins.open", mock_open()) as mock_file, \
+        patch("json.dump") as mock_json_dump:
+
+        mock_extract.return_value = mock_data
+
+        mock_fig = MagicMock()
+        mock_ax = MagicMock()
+        mock_plt.subplots.return_value = (mock_fig, mock_ax)
+
+        passed, acknowledgements, plt_fig, stats = check_tcm_acknowledgement_delay(mock_mcap_path, max_delay_sec, fake_save_dir, fake_save_dir, fake_save_dir)
+    
+        assert passed
+        assert len(acknowledgements) == 3
+        assert plt_fig is not None
+        assert stats["minimum"] == approx(0.01, rel=1e-2)
+        assert stats["maximum"] == approx(0.14, rel=1e-2)
+        assert stats["sample_count"] == 3
+
+
+def test_failing_check_tcm_acknowledgement_delay(mock_mcap_path):
+    fake_save_dir = '/fake/dir'
+    max_delay_sec = 1
+    mock_data = {
+        '/message/incoming_geofence_control':
+        [
+            [142.25, 142.31, 144.76],
+            [
+                SimpleNamespace(
+                    reqid=SimpleNamespace(
+                        id=np.array([246, 136,  69,  62, 167, 197,  69,  12], dtype=np.int64) # Changed value such that there is a TCM received that isn't acknowledged
+                    ),
+                    msgnum=1
+                ),
+                SimpleNamespace(
+                    reqid=SimpleNamespace(
+                        id=np.array([246, 136,  69,  62, 167, 197,  69,  17], dtype=np.int64)
+                    ),
+                    msgnum=2
+                ),
+                SimpleNamespace(
+                    reqid=SimpleNamespace(
+                        id=np.array([253, 183,   5,  51, 158,  15,  76,  27]) 
+                    ),
+                    msgnum=1
+                )
+            ]
+        ],
+        '/message/outgoing_mobility_operation':
+        [
+            [142.28, 143.45, 144.77],
+            [
+                SimpleNamespace(
+                    strategy="carma3/Geofence_Acknowledgement",
+                    strategy_params='traffic_control_id:f688453ea7c54511, msgnum:1, acknowledgement:1, reason:Successfully processed TCM.'
+                ),
+                SimpleNamespace(
+                    strategy="carma3/Geofence_Acknowledgement",
+                    strategy_params='traffic_control_id:f688453ea7c54511, msgnum:2, acknowledgement:1, reason:Successfully processed TCM.'
+                ),
+                SimpleNamespace(
+                    strategy="carma3/Geofence_Acknowledgement",
+                    strategy_params='traffic_control_id:fdb705339e0f4c1b, msgnum:1, acknowledgement:1, reason:Dropping received TrafficControl message with already handled id: 008ba29f-41eb-4df1-cf0a-4e3a2ab11096'
+                )
+            ]
+        ]
+    }
+
+    with patch("message_scripts.extract_mcap_data") as mock_extract, \
+        patch('message_scripts.plt') as mock_plt:
+
+        mock_extract.return_value = mock_data
+
+        mock_fig = MagicMock()
+        mock_ax = MagicMock()
+        mock_plt.subplots.return_value = (mock_fig, mock_ax)
+
+        passed, acknowledgements, plt_fig, stats = check_tcm_acknowledgement_delay(mock_mcap_path, max_delay_sec)
+    
+        assert not passed
+        assert len(acknowledgements) == 2
+        assert plt_fig is not None
+        assert stats["minimum"] == approx(0.01, rel=1e-2)
+        assert stats["maximum"] == approx(1.14, rel=1e-2)
+        assert stats["sample_count"] == 2
+
+
+def test_passing_check_tcm_response_time(mock_mcap_path):
+    fake_save_dir = '/fake/dir'
+    expected_duration_sec = 1
+
+    mock_data = {
+        '/message/outgoing_geofence_request':
+        [
+            [141.89, 142.02, 144.24],
+            [
+                SimpleNamespace(
+                    reqid=SimpleNamespace(
+                        id=np.array([246, 136, 69, 62, 167, 197, 69, 17], dtype=np.int64)
+                    )
+                ),
+                SimpleNamespace(
+                    reqid=SimpleNamespace(
+                        id=np.array([246, 136, 69, 62, 167, 197, 69, 17], dtype=np.int64)
+                    )
+                ),
+                SimpleNamespace(
+                    reqid=SimpleNamespace(
+                        id=np.array([253, 183,   5,  51, 158,  15,  76,  27], dtype=np.int64)
+                    )
+                )
+            ]
+        ],
+        '/message/incoming_geofence_control':
+        [
+            [142.25, 142.31, 144.76],
+            [
+                SimpleNamespace(
+                    reqid=SimpleNamespace(
+                        id=np.array([246, 136,  69,  62, 167, 197,  69,  17], dtype=np.int64)
+                    ),
+                    msgnum=1
+                ),
+                SimpleNamespace(
+                    reqid=SimpleNamespace(
+                        id=np.array([246, 136,  69,  62, 167, 197,  69,  17], dtype=np.int64)
+                    ),
+                    msgnum=2
+                ),
+                SimpleNamespace(
+                    reqid=SimpleNamespace(
+                        id=np.array([253, 183,   5,  51, 158,  15,  76,  27], dtype=np.int64)
+                    ),
+                    msgnum=1
+                )
+            ]
+        ]
+    }
+
+    with patch('message_scripts.extract_mcap_data') as mock_extract, \
+        patch('message_scripts.plt') as mock_plt, \
+        patch.object(Path, "mkdir") as mock_mkdir, \
+        patch("numpy.savez") as mock_savez, \
+        patch("builtins.open", mock_open()) as mock_file, \
+        patch("json.dump") as mock_json_dump:
+
+        mock_extract.return_value = mock_data
+
+        mock_fig = MagicMock()
+        mock_ax = MagicMock()
+        mock_plt.subplots.return_value = (mock_fig, mock_ax)
+
+        passed = check_tcm_response_time(mock_mcap_path, expected_duration_sec, fake_save_dir, fake_save_dir, fake_save_dir)
+
+        assert passed
+
+
+def test_failing_check_tcm_response_time(mock_mcap_path):
+    fake_save_dir = '/fake/dir'
+    expected_duration_sec = 1
+
+    mock_data = {
+        '/message/outgoing_geofence_request':
+        [
+            [141.89, 142.02, 144.24],
+            [
+                SimpleNamespace(
+                    reqid=SimpleNamespace(
+                        id=np.array([246, 136, 69, 62, 167, 197, 69, 17], dtype=np.int64)
+                    )
+                ),
+                SimpleNamespace(
+                    reqid=SimpleNamespace(
+                        id=np.array([246, 136, 69, 62, 167, 197, 69, 17], dtype=np.int64)
+                    )
+                ),
+                SimpleNamespace(
+                    reqid=SimpleNamespace(
+                        id=np.array([253, 183,   5,  51, 158,  15,  76,  27], dtype=np.int64)
+                    )
+                )
+            ]
+        ],
+        '/message/incoming_geofence_control':
+        [
+            [142.25, 142.31, 145.76], # Will fail because the 3rd TCM is received more than expected_duration_sec after the related TCR was sent
+            [
+                SimpleNamespace(
+                    reqid=SimpleNamespace(
+                        id=np.array([246, 136,  69,  62, 167, 197,  69,  17], dtype=np.int64)
+                    ),
+                    msgnum=1
+                ),
+                SimpleNamespace(
+                    reqid=SimpleNamespace(
+                        id=np.array([246, 136,  69,  62, 167, 197,  69,  17], dtype=np.int64)
+                    ),
+                    msgnum=2
+                ),
+                SimpleNamespace(
+                    reqid=SimpleNamespace(
+                        id=np.array([253, 183,   5,  51, 158,  15,  76,  27], dtype=np.int64)
+                    ),
+                    msgnum=1
+                )
+            ]
+        ]
+    }
+
+    with patch('message_scripts.extract_mcap_data') as mock_extract, \
+        patch('message_scripts.plt') as mock_plt, \
+        patch.object(Path, "mkdir") as mock_mkdir, \
+        patch("numpy.savez") as mock_savez, \
+        patch("builtins.open", mock_open()) as mock_file, \
+        patch("json.dump") as mock_json_dump:
+
+        mock_extract.return_value = mock_data
+
+        mock_fig = MagicMock()
+        mock_ax = MagicMock()
+        mock_plt.subplots.return_value = (mock_fig, mock_ax)
+
+        passed = check_tcm_response_time(mock_mcap_path, expected_duration_sec, fake_save_dir, fake_save_dir, None)
+
+        assert not passed
+
+
+def test_process_cc_logs_for_tcr_tcm_data():
+    log_date = "2025-05-20"
+    max_delay_sec = 0.1
+    expected_rate_hz = 20
+
+    expected_reqids = ['F688453EA7C54511', 'FDB705339E0F4C1B', 'F804AA710EA64E31', 'D3F3512874AC47A1']
+    rate_tcm_ids = ['00305feb9eac2d077bd5f534833d0152', '008ba29f41eb4df1cf0a4e3a2ab11094']
+    inf_rate_tcm_ids = ['00305feb9eac2d077bd5f534833d0153', '008ba29f41eb4df1cf0a4e3a2ab11095']
+    
+    # Fake files in the directory
+    fake_files = ['file1.txt']
+    fake_save_dir = '/fake/dir'
+
+    sample_lines = [
+        '[DEBUG 19:03:20.071 [TcmReqServlet] - <?xml version="1.0" encoding="UTF-8"?><TrafficControlRequest port="33333" list="true"><reqid>F688453EA7C54511</reqid><reqseq>0</reqseq><scale>-1</scale><bounds><TrafficControlBounds><oldest>29107863</oldest><reflon>-771510186</reflon><reflat>389548654</reflat><offsets><OffsetPoint><deltax>3015</deltax><deltay>0</deltay></OffsetPoint><OffsetPoint><deltax>3015</deltax><deltay>1049</deltay></OffsetPoint><OffsetPoint><deltax>0</deltax><deltay>1049</deltay></OffsetPoint></offsets></TrafficControlBounds></bounds></TrafficControlRequest>',
+        '[DEBUG 19:03:20.077 [TcmReqServlet] - <?xml version="1.0" encoding="UTF-8"?><TrafficControlMessage><tcmV01><reqid>F688453EA7C54511</reqid><reqseq>0</reqseq><msgtot>2</msgtot><msgnum>1</msgnum><id>008ba29f41eb4df1cf0a4e3a2ab11096</id><updated>0</updated><package><label>workzone</label><tcids><Id128b>008ba29f41eb4df1cf0a4e3a2ab11096</Id128b></tcids></package><params><vclasses><micromobile/><motorcycle/><passenger-car/><light-truck-van/><bus/><two-axle-six-tire-single-unit-truck/><three-axle-single-unit-truck/><four-or-more-axle-single-unit-truck/><four-or-fewer-axle-single-trailer-truck/><five-axle-single-trailer-truck/><six-or-more-axle-single-trailer-truck/><five-or-fewer-axle-multi-trailer-truck/><six-axle-multi-trailer-truck/><seven-or-more-axle-multi-trailer-truck/></vclasses><schedule><start>29109288</start><end>153722867280912</end><dow>1111111</dow></schedule><regulatory><true/></regulatory><detail><closed><notopen/></closed></detail></params><geometry><proj>epsg:3785</proj><datum>WGS84</datum><reftime>29109288</reftime><reflon>-771486221</reflon><reflat>389549122</reflat><refelv>0</refelv><heading>3312</heading><nodes><PathNode><x>5</x><y>0</y><width>1</width></PathNode><PathNode><x>-1491</x><y>94</y><width>8</width></PathNode><PathNode><x>-830</x><y>80</y><width>3</width></PathNode></nodes></geometry></tcmV01></TrafficControlMessage>',
+        '[DEBUG 19:03:20.078 [TcmReqServlet] - <?xml version="1.0" encoding="UTF-8"?><TrafficControlMessage><tcmV01><reqid>F688453EA7C54511</reqid><reqseq>0</reqseq><msgtot>2</msgtot><msgnum>2</msgnum><id>00305feb9eac2d077bd5f534833d0151</id><updated>0</updated><package><label>workzone</label><tcids><Id128b>00305feb9eac2d077bd5f534833d0151</Id128b></tcids></package><params><vclasses><micromobile/><motorcycle/><passenger-car/><light-truck-van/><bus/><two-axle-six-tire-single-unit-truck/><three-axle-single-unit-truck/><four-or-more-axle-single-unit-truck/><four-or-fewer-axle-single-trailer-truck/><five-axle-single-trailer-truck/><six-or-more-axle-single-trailer-truck/><five-or-fewer-axle-multi-trailer-truck/><six-axle-multi-trailer-truck/><seven-or-more-axle-multi-trailer-truck/></vclasses><schedule><start>29129391</start><end>153722867280912</end><dow>1111111</dow></schedule><regulatory><true/></regulatory><detail><maxspeed>45</maxspeed></detail></params><geometry><proj>epsg:3785</proj><datum>WGS84</datum><reftime>29129391</reftime><reflon>-771488786</reflon><reflat>389548996</reflat><refelv>0</refelv><heading>3312</heading><nodes><PathNode><x>1</x><y>0</y><width>-1</width></PathNode><PathNode><x>1489</x><y>-152</y><width>24</width></PathNode><PathNode><x>1496</x><y>-92</y><width>9</width></PathNode><PathNode><x>60</x><y>-3</y><width>2</width></PathNode></nodes></geometry></tcmV01></TrafficControlMessage>',
+        '[DEBUG 19:03:22.544 [TcmReqServlet] - <?xml version="1.0" encoding="UTF-8"?><TrafficControlRequest port="33333" list="true"><reqid>FDB705339E0F4C1B</reqid><reqseq>0</reqseq><scale>-1</scale><bounds><TrafficControlBounds><oldest>29107863</oldest><reflon>-771510186</reflon><reflat>389548654</reflat><offsets><OffsetPoint><deltax>3015</deltax><deltay>0</deltay></OffsetPoint><OffsetPoint><deltax>3015</deltax><deltay>1049</deltay></OffsetPoint><OffsetPoint><deltax>0</deltax><deltay>1049</deltay></OffsetPoint></offsets></TrafficControlBounds></bounds></TrafficControlRequest>',
+        '[DEBUG 19:03:22.547 [TcmReqServlet] - <?xml version="1.0" encoding="UTF-8"?><TrafficControlMessage><tcmV01><reqid>FDB705339E0F4C1B</reqid><reqseq>0</reqseq><msgtot>2</msgtot><msgnum>1</msgnum><id>008ba29f41eb4df1cf0a4e3a2ab11094</id><updated>0</updated><package><label>workzone</label><tcids><Id128b>008ba29f41eb4df1cf0a4e3a2ab11096</Id128b></tcids></package><params><vclasses><micromobile/><motorcycle/><passenger-car/><light-truck-van/><bus/><two-axle-six-tire-single-unit-truck/><three-axle-single-unit-truck/><four-or-more-axle-single-unit-truck/><four-or-fewer-axle-single-trailer-truck/><five-axle-single-trailer-truck/><six-or-more-axle-single-trailer-truck/><five-or-fewer-axle-multi-trailer-truck/><six-axle-multi-trailer-truck/><seven-or-more-axle-multi-trailer-truck/></vclasses><schedule><start>29109288</start><end>153722867280912</end><dow>1111111</dow></schedule><regulatory><true/></regulatory><detail><closed><notopen/></closed></detail></params><geometry><proj>epsg:3785</proj><datum>WGS84</datum><reftime>29109288</reftime><reflon>-771486221</reflon><reflat>389549122</reflat><refelv>0</refelv><heading>3312</heading><nodes><PathNode><x>5</x><y>0</y><width>1</width></PathNode><PathNode><x>-1491</x><y>94</y><width>8</width></PathNode><PathNode><x>-830</x><y>80</y><width>3</width></PathNode></nodes></geometry></tcmV01></TrafficControlMessage>',
+        '[DEBUG 19:03:22.548 [TcmReqServlet] - <?xml version="1.0" encoding="UTF-8"?><TrafficControlMessage><tcmV01><reqid>FDB705339E0F4C1B</reqid><reqseq>0</reqseq><msgtot>2</msgtot><msgnum>2</msgnum><id>00305feb9eac2d077bd5f534833d0152</id><updated>0</updated><package><label>workzone</label><tcids><Id128b>00305feb9eac2d077bd5f534833d0151</Id128b></tcids></package><params><vclasses><micromobile/><motorcycle/><passenger-car/><light-truck-van/><bus/><two-axle-six-tire-single-unit-truck/><three-axle-single-unit-truck/><four-or-more-axle-single-unit-truck/><four-or-fewer-axle-single-trailer-truck/><five-axle-single-trailer-truck/><six-or-more-axle-single-trailer-truck/><five-or-fewer-axle-multi-trailer-truck/><six-axle-multi-trailer-truck/><seven-or-more-axle-multi-trailer-truck/></vclasses><schedule><start>29129391</start><end>153722867280912</end><dow>1111111</dow></schedule><regulatory><true/></regulatory><detail><maxspeed>45</maxspeed></detail></params><geometry><proj>epsg:3785</proj><datum>WGS84</datum><reftime>29129391</reftime><reflon>-771488786</reflon><reflat>389548996</reflat><refelv>0</refelv><heading>3312</heading><nodes><PathNode><x>1</x><y>0</y><width>-1</width></PathNode><PathNode><x>1489</x><y>-152</y><width>24</width></PathNode><PathNode><x>1496</x><y>-92</y><width>9</width></PathNode><PathNode><x>60</x><y>-3</y><width>2</width></PathNode></nodes></geometry></tcmV01></TrafficControlMessage>',
+        '[DEBUG 19:03:22.647 [TcmReqServlet] - <?xml version="1.0" encoding="UTF-8"?><TrafficControlMessage><tcmV01><reqid>FDB705339E0F4C1B</reqid><reqseq>0</reqseq><msgtot>2</msgtot><msgnum>1</msgnum><id>008ba29f41eb4df1cf0a4e3a2ab11094</id><updated>0</updated><package><label>workzone</label><tcids><Id128b>008ba29f41eb4df1cf0a4e3a2ab11096</Id128b></tcids></package><params><vclasses><micromobile/><motorcycle/><passenger-car/><light-truck-van/><bus/><two-axle-six-tire-single-unit-truck/><three-axle-single-unit-truck/><four-or-more-axle-single-unit-truck/><four-or-fewer-axle-single-trailer-truck/><five-axle-single-trailer-truck/><six-or-more-axle-single-trailer-truck/><five-or-fewer-axle-multi-trailer-truck/><six-axle-multi-trailer-truck/><seven-or-more-axle-multi-trailer-truck/></vclasses><schedule><start>29109288</start><end>153722867280912</end><dow>1111111</dow></schedule><regulatory><true/></regulatory><detail><closed><notopen/></closed></detail></params><geometry><proj>epsg:3785</proj><datum>WGS84</datum><reftime>29109288</reftime><reflon>-771486221</reflon><reflat>389549122</reflat><refelv>0</refelv><heading>3312</heading><nodes><PathNode><x>5</x><y>0</y><width>1</width></PathNode><PathNode><x>-1491</x><y>94</y><width>8</width></PathNode><PathNode><x>-830</x><y>80</y><width>3</width></PathNode></nodes></geometry></tcmV01></TrafficControlMessage>',
+        '[DEBUG 19:03:22.648 [TcmReqServlet] - <?xml version="1.0" encoding="UTF-8"?><TrafficControlMessage><tcmV01><reqid>FDB705339E0F4C1B</reqid><reqseq>0</reqseq><msgtot>2</msgtot><msgnum>2</msgnum><id>00305feb9eac2d077bd5f534833d0152</id><updated>0</updated><package><label>workzone</label><tcids><Id128b>00305feb9eac2d077bd5f534833d0151</Id128b></tcids></package><params><vclasses><micromobile/><motorcycle/><passenger-car/><light-truck-van/><bus/><two-axle-six-tire-single-unit-truck/><three-axle-single-unit-truck/><four-or-more-axle-single-unit-truck/><four-or-fewer-axle-single-trailer-truck/><five-axle-single-trailer-truck/><six-or-more-axle-single-trailer-truck/><five-or-fewer-axle-multi-trailer-truck/><six-axle-multi-trailer-truck/><seven-or-more-axle-multi-trailer-truck/></vclasses><schedule><start>29129391</start><end>153722867280912</end><dow>1111111</dow></schedule><regulatory><true/></regulatory><detail><maxspeed>45</maxspeed></detail></params><geometry><proj>epsg:3785</proj><datum>WGS84</datum><reftime>29129391</reftime><reflon>-771488786</reflon><reflat>389548996</reflat><refelv>0</refelv><heading>3312</heading><nodes><PathNode><x>1</x><y>0</y><width>-1</width></PathNode><PathNode><x>1489</x><y>-152</y><width>24</width></PathNode><PathNode><x>1496</x><y>-92</y><width>9</width></PathNode><PathNode><x>60</x><y>-3</y><width>2</width></PathNode></nodes></geometry></tcmV01></TrafficControlMessage>',
+        '[DEBUG 19:03:25.601 [TcmReqServlet] - <?xml version="1.0" encoding="UTF-8"?><TrafficControlRequest port="33333" list="true"><reqid>F804AA710EA64E31</reqid><reqseq>0</reqseq><scale>-1</scale><bounds><TrafficControlBounds><oldest>29107863</oldest><reflon>-771510186</reflon><reflat>389548654</reflat><offsets><OffsetPoint><deltax>3015</deltax><deltay>0</deltay></OffsetPoint><OffsetPoint><deltax>3015</deltax><deltay>1049</deltay></OffsetPoint><OffsetPoint><deltax>0</deltax><deltay>1049</deltay></OffsetPoint></offsets></TrafficControlBounds></bounds></TrafficControlRequest>',
+        '[DEBUG 19:03:25.605 [TcmReqServlet] - <?xml version="1.0" encoding="UTF-8"?><TrafficControlMessage><tcmV01><reqid>F804AA710EA64E31</reqid><reqseq>0</reqseq><msgtot>2</msgtot><msgnum>1</msgnum><id>008ba29f41eb4df1cf0a4e3a2ab11095</id><updated>0</updated><package><label>workzone</label><tcids><Id128b>008ba29f41eb4df1cf0a4e3a2ab11096</Id128b></tcids></package><params><vclasses><micromobile/><motorcycle/><passenger-car/><light-truck-van/><bus/><two-axle-six-tire-single-unit-truck/><three-axle-single-unit-truck/><four-or-more-axle-single-unit-truck/><four-or-fewer-axle-single-trailer-truck/><five-axle-single-trailer-truck/><six-or-more-axle-single-trailer-truck/><five-or-fewer-axle-multi-trailer-truck/><six-axle-multi-trailer-truck/><seven-or-more-axle-multi-trailer-truck/></vclasses><schedule><start>29109288</start><end>153722867280912</end><dow>1111111</dow></schedule><regulatory><true/></regulatory><detail><closed><notopen/></closed></detail></params><geometry><proj>epsg:3785</proj><datum>WGS84</datum><reftime>29109288</reftime><reflon>-771486221</reflon><reflat>389549122</reflat><refelv>0</refelv><heading>3312</heading><nodes><PathNode><x>5</x><y>0</y><width>1</width></PathNode><PathNode><x>-1491</x><y>94</y><width>8</width></PathNode><PathNode><x>-830</x><y>80</y><width>3</width></PathNode></nodes></geometry></tcmV01></TrafficControlMessage>',
+        '[DEBUG 19:03:25.606 [TcmReqServlet] - <?xml version="1.0" encoding="UTF-8"?><TrafficControlMessage><tcmV01><reqid>F804AA710EA64E31</reqid><reqseq>0</reqseq><msgtot>2</msgtot><msgnum>2</msgnum><id>00305feb9eac2d077bd5f534833d0153</id><updated>0</updated><package><label>workzone</label><tcids><Id128b>00305feb9eac2d077bd5f534833d0151</Id128b></tcids></package><params><vclasses><micromobile/><motorcycle/><passenger-car/><light-truck-van/><bus/><two-axle-six-tire-single-unit-truck/><three-axle-single-unit-truck/><four-or-more-axle-single-unit-truck/><four-or-fewer-axle-single-trailer-truck/><five-axle-single-trailer-truck/><six-or-more-axle-single-trailer-truck/><five-or-fewer-axle-multi-trailer-truck/><six-axle-multi-trailer-truck/><seven-or-more-axle-multi-trailer-truck/></vclasses><schedule><start>29129391</start><end>153722867280912</end><dow>1111111</dow></schedule><regulatory><true/></regulatory><detail><maxspeed>45</maxspeed></detail></params><geometry><proj>epsg:3785</proj><datum>WGS84</datum><reftime>29129391</reftime><reflon>-771488786</reflon><reflat>389548996</reflat><refelv>0</refelv><heading>3312</heading><nodes><PathNode><x>1</x><y>0</y><width>-1</width></PathNode><PathNode><x>1489</x><y>-152</y><width>24</width></PathNode><PathNode><x>1496</x><y>-92</y><width>9</width></PathNode><PathNode><x>60</x><y>-3</y><width>2</width></PathNode></nodes></geometry></tcmV01></TrafficControlMessage>',
+        '[DEBUG 19:03:25.605 [TcmReqServlet] - <?xml version="1.0" encoding="UTF-8"?><TrafficControlMessage><tcmV01><reqid>F804AA710EA64E31</reqid><reqseq>0</reqseq><msgtot>2</msgtot><msgnum>1</msgnum><id>008ba29f41eb4df1cf0a4e3a2ab11095</id><updated>0</updated><package><label>workzone</label><tcids><Id128b>008ba29f41eb4df1cf0a4e3a2ab11096</Id128b></tcids></package><params><vclasses><micromobile/><motorcycle/><passenger-car/><light-truck-van/><bus/><two-axle-six-tire-single-unit-truck/><three-axle-single-unit-truck/><four-or-more-axle-single-unit-truck/><four-or-fewer-axle-single-trailer-truck/><five-axle-single-trailer-truck/><six-or-more-axle-single-trailer-truck/><five-or-fewer-axle-multi-trailer-truck/><six-axle-multi-trailer-truck/><seven-or-more-axle-multi-trailer-truck/></vclasses><schedule><start>29109288</start><end>153722867280912</end><dow>1111111</dow></schedule><regulatory><true/></regulatory><detail><closed><notopen/></closed></detail></params><geometry><proj>epsg:3785</proj><datum>WGS84</datum><reftime>29109288</reftime><reflon>-771486221</reflon><reflat>389549122</reflat><refelv>0</refelv><heading>3312</heading><nodes><PathNode><x>5</x><y>0</y><width>1</width></PathNode><PathNode><x>-1491</x><y>94</y><width>8</width></PathNode><PathNode><x>-830</x><y>80</y><width>3</width></PathNode></nodes></geometry></tcmV01></TrafficControlMessage>',
+        '[DEBUG 19:03:25.606 [TcmReqServlet] - <?xml version="1.0" encoding="UTF-8"?><TrafficControlMessage><tcmV01><reqid>F804AA710EA64E31</reqid><reqseq>0</reqseq><msgtot>2</msgtot><msgnum>2</msgnum><id>00305feb9eac2d077bd5f534833d0153</id><updated>0</updated><package><label>workzone</label><tcids><Id128b>00305feb9eac2d077bd5f534833d0151</Id128b></tcids></package><params><vclasses><micromobile/><motorcycle/><passenger-car/><light-truck-van/><bus/><two-axle-six-tire-single-unit-truck/><three-axle-single-unit-truck/><four-or-more-axle-single-unit-truck/><four-or-fewer-axle-single-trailer-truck/><five-axle-single-trailer-truck/><six-or-more-axle-single-trailer-truck/><five-or-fewer-axle-multi-trailer-truck/><six-axle-multi-trailer-truck/><seven-or-more-axle-multi-trailer-truck/></vclasses><schedule><start>29129391</start><end>153722867280912</end><dow>1111111</dow></schedule><regulatory><true/></regulatory><detail><maxspeed>45</maxspeed></detail></params><geometry><proj>epsg:3785</proj><datum>WGS84</datum><reftime>29129391</reftime><reflon>-771488786</reflon><reflat>389548996</reflat><refelv>0</refelv><heading>3312</heading><nodes><PathNode><x>1</x><y>0</y><width>-1</width></PathNode><PathNode><x>1489</x><y>-152</y><width>24</width></PathNode><PathNode><x>1496</x><y>-92</y><width>9</width></PathNode><PathNode><x>60</x><y>-3</y><width>2</width></PathNode></nodes></geometry></tcmV01></TrafficControlMessage>',
+        '[DEBUG 19:03:28.521 [TcmReqServlet] - <?xml version="1.0" encoding="UTF-8"?><TrafficControlRequest port="33333" list="true"><reqid>D3F3512874AC47A1</reqid><reqseq>0</reqseq><scale>-1</scale><bounds><TrafficControlBounds><oldest>29107863</oldest><reflon>-771510186</reflon><reflat>389548654</reflat><offsets><OffsetPoint><deltax>3015</deltax><deltay>0</deltay></OffsetPoint><OffsetPoint><deltax>3015</deltax><deltay>1049</deltay></OffsetPoint><OffsetPoint><deltax>0</deltax><deltay>1049</deltay></OffsetPoint></offsets></TrafficControlBounds></bounds></TrafficControlRequest>',
+        '[DEBUG 19:03:28.525 [TcmReqServlet] - <?xml version="1.0" encoding="UTF-8"?><TrafficControlMessage><tcmV01><reqid>D3F3512874AC47A1</reqid><reqseq>0</reqseq><msgtot>2</msgtot><msgnum>1</msgnum><id>008ba29f41eb4df1cf0a4e3a2ab11096</id><updated>0</updated><package><label>workzone</label><tcids><Id128b>008ba29f41eb4df1cf0a4e3a2ab11096</Id128b></tcids></package><params><vclasses><micromobile/><motorcycle/><passenger-car/><light-truck-van/><bus/><two-axle-six-tire-single-unit-truck/><three-axle-single-unit-truck/><four-or-more-axle-single-unit-truck/><four-or-fewer-axle-single-trailer-truck/><five-axle-single-trailer-truck/><six-or-more-axle-single-trailer-truck/><five-or-fewer-axle-multi-trailer-truck/><six-axle-multi-trailer-truck/><seven-or-more-axle-multi-trailer-truck/></vclasses><schedule><start>29109288</start><end>153722867280912</end><dow>1111111</dow></schedule><regulatory><true/></regulatory><detail><closed><notopen/></closed></detail></params><geometry><proj>epsg:3785</proj><datum>WGS84</datum><reftime>29109288</reftime><reflon>-771486221</reflon><reflat>389549122</reflat><refelv>0</refelv><heading>3312</heading><nodes><PathNode><x>5</x><y>0</y><width>1</width></PathNode><PathNode><x>-1491</x><y>94</y><width>8</width></PathNode><PathNode><x>-830</x><y>80</y><width>3</width></PathNode></nodes></geometry></tcmV01></TrafficControlMessage>',
+        '[DEBUG 19:03:28.526 [TcmReqServlet] - <?xml version="1.0" encoding="UTF-8"?><TrafficControlMessage><tcmV01><reqid>D3F3512874AC47A1</reqid><reqseq>0</reqseq><msgtot>2</msgtot><msgnum>2</msgnum><id>00305feb9eac2d077bd5f534833d0151</id><updated>0</updated><package><label>workzone</label><tcids><Id128b>00305feb9eac2d077bd5f534833d0151</Id128b></tcids></package><params><vclasses><micromobile/><motorcycle/><passenger-car/><light-truck-van/><bus/><two-axle-six-tire-single-unit-truck/><three-axle-single-unit-truck/><four-or-more-axle-single-unit-truck/><four-or-fewer-axle-single-trailer-truck/><five-axle-single-trailer-truck/><six-or-more-axle-single-trailer-truck/><five-or-fewer-axle-multi-trailer-truck/><six-axle-multi-trailer-truck/><seven-or-more-axle-multi-trailer-truck/></vclasses><schedule><start>29129391</start><end>153722867280912</end><dow>1111111</dow></schedule><regulatory><true/></regulatory><detail><maxspeed>45</maxspeed></detail></params><geometry><proj>epsg:3785</proj><datum>WGS84</datum><reftime>29129391</reftime><reflon>-771488786</reflon><reflat>389548996</reflat><refelv>0</refelv><heading>3312</heading><nodes><PathNode><x>1</x><y>0</y><width>-1</width></PathNode><PathNode><x>1489</x><y>-152</y><width>24</width></PathNode><PathNode><x>1496</x><y>-92</y><width>9</width></PathNode><PathNode><x>60</x><y>-3</y><width>2</width></PathNode></nodes></geometry></tcmV01></TrafficControlMessage>'
+    ]
+
+    file_contents = "\n".join(sample_lines)+"\n"
+
+    with patch('os.listdir', return_value=fake_files), \
+        patch('os.path.isfile', return_value=True), \
+        patch('builtins.open', mock_open(read_data=file_contents)) as mock_file, \
+        patch('message_scripts.plt') as mock_plt, \
+        patch.object(Path, "mkdir") as mock_mkdir, \
+        patch("numpy.savez") as mock_savez, \
+        patch("json.dump") as mock_json_dump:
+
+        mock_fig = MagicMock()
+        mock_ax1 = MagicMock()
+        mock_ax2 = MagicMock()
+        mock_plt.subplots.return_value = (mock_fig, (mock_ax1, mock_ax2))
+
+        with np.errstate(invalid='ignore'): # Purposefully ignoring error state on this, the sample cc logs will cause a float('inf') value for the rate which causes warning on calculating error statistics
+            all_results, _ = process_cc_logs_for_tcr_tcm_data(fake_save_dir, log_date, max_delay_sec, expected_rate_hz, fake_save_dir, fake_save_dir, fake_save_dir)
+
+        for reqid in expected_reqids:
+            assert reqid in all_results
+
+        for reqid, data in all_results.items():
+            assert isinstance(data, dict)
+
+            for key in ["first_tcm_time", "response_delay", "tcr_time"]:
+                assert key in data
+
+            for tcm_id, tcm_data in data.items():
+                if tcm_id in ["first_tcm_time", "response_delay", "tcr_time"]:
+                    continue
+                assert isinstance(tcm_data, dict)
+
+                for field in ["count", "msgnum", "rate", "timestamps"]:
+                    assert field in tcm_data
+
+                if tcm_id in rate_tcm_ids:
+                    assert tcm_data["rate"] == approx(expected_rate_hz, rel=0.05)
+
+                if tcm_id in inf_rate_tcm_ids:
+                    assert tcm_data["rate"] == float('inf')
+
+
+def test_bad_data_process_cc_logs_for_tcr_tcm_data():
+    log_date = "2025-05-20"
+    max_delay_sec = 0.1
+    expected_rate_hz = 0
+
+    expected_reqids = ['F688453EA7C54511', 'FDB705339E0F4C1B', 'F804AA710EA64E31', 'D3F3512874AC47A1']
+    
+    # Fake files in the directory
+    fake_files = ['file1.txt']
+    fake_save_dir = '/fake/dir'
+
+    sample_lines = [
+        'line with out TCR / TCM written out',
+        'TrafficControlRequest missing time stamp',
+        '[DEBUG 15:20:05.383 [TcmReqServlet] <TrafficControlMessage> missing req id]',
+        '[DEBUG 15:25:25.937 [TcmReqServlet] TrafficControlMessage missing <> on TCM/TCR <reqid>F688453EA7C54511</reqid>]',
+        '[DEBUG 15:35:35.037 [TcmReqServlet] <TrafficControlMessage> missing tcm msg id <reqid>F688453EA7C54511</reqid>]',
+        '[DEBUG 15:45:45.203 [TcmReqServlet] <TrafficControlMessage> missing tcm msgnum <reqid>F688453EA7C54511</reqid>]<id>008ba29f41eb4df1cf0a4e3a2ab11096</id>',
+        # Regular log lines below - asserts should be similar to above test
+        '[DEBUG 19:03:20.071 [TcmReqServlet] - <?xml version="1.0" encoding="UTF-8"?><TrafficControlRequest port="33333" list="true"><reqid>F688453EA7C54511</reqid><reqseq>0</reqseq><scale>-1</scale><bounds><TrafficControlBounds><oldest>29107863</oldest><reflon>-771510186</reflon><reflat>389548654</reflat><offsets><OffsetPoint><deltax>3015</deltax><deltay>0</deltay></OffsetPoint><OffsetPoint><deltax>3015</deltax><deltay>1049</deltay></OffsetPoint><OffsetPoint><deltax>0</deltax><deltay>1049</deltay></OffsetPoint></offsets></TrafficControlBounds></bounds></TrafficControlRequest>',
+        '[DEBUG 19:03:20.077 [TcmReqServlet] - <?xml version="1.0" encoding="UTF-8"?><TrafficControlMessage><tcmV01><reqid>F688453EA7C54511</reqid><reqseq>0</reqseq><msgtot>2</msgtot><msgnum>1</msgnum><id>008ba29f41eb4df1cf0a4e3a2ab11096</id><updated>0</updated><package><label>workzone</label><tcids><Id128b>008ba29f41eb4df1cf0a4e3a2ab11096</Id128b></tcids></package><params><vclasses><micromobile/><motorcycle/><passenger-car/><light-truck-van/><bus/><two-axle-six-tire-single-unit-truck/><three-axle-single-unit-truck/><four-or-more-axle-single-unit-truck/><four-or-fewer-axle-single-trailer-truck/><five-axle-single-trailer-truck/><six-or-more-axle-single-trailer-truck/><five-or-fewer-axle-multi-trailer-truck/><six-axle-multi-trailer-truck/><seven-or-more-axle-multi-trailer-truck/></vclasses><schedule><start>29109288</start><end>153722867280912</end><dow>1111111</dow></schedule><regulatory><true/></regulatory><detail><closed><notopen/></closed></detail></params><geometry><proj>epsg:3785</proj><datum>WGS84</datum><reftime>29109288</reftime><reflon>-771486221</reflon><reflat>389549122</reflat><refelv>0</refelv><heading>3312</heading><nodes><PathNode><x>5</x><y>0</y><width>1</width></PathNode><PathNode><x>-1491</x><y>94</y><width>8</width></PathNode><PathNode><x>-830</x><y>80</y><width>3</width></PathNode></nodes></geometry></tcmV01></TrafficControlMessage>',
+        '[DEBUG 19:03:20.078 [TcmReqServlet] - <?xml version="1.0" encoding="UTF-8"?><TrafficControlMessage><tcmV01><reqid>F688453EA7C54511</reqid><reqseq>0</reqseq><msgtot>2</msgtot><msgnum>2</msgnum><id>00305feb9eac2d077bd5f534833d0151</id><updated>0</updated><package><label>workzone</label><tcids><Id128b>00305feb9eac2d077bd5f534833d0151</Id128b></tcids></package><params><vclasses><micromobile/><motorcycle/><passenger-car/><light-truck-van/><bus/><two-axle-six-tire-single-unit-truck/><three-axle-single-unit-truck/><four-or-more-axle-single-unit-truck/><four-or-fewer-axle-single-trailer-truck/><five-axle-single-trailer-truck/><six-or-more-axle-single-trailer-truck/><five-or-fewer-axle-multi-trailer-truck/><six-axle-multi-trailer-truck/><seven-or-more-axle-multi-trailer-truck/></vclasses><schedule><start>29129391</start><end>153722867280912</end><dow>1111111</dow></schedule><regulatory><true/></regulatory><detail><maxspeed>45</maxspeed></detail></params><geometry><proj>epsg:3785</proj><datum>WGS84</datum><reftime>29129391</reftime><reflon>-771488786</reflon><reflat>389548996</reflat><refelv>0</refelv><heading>3312</heading><nodes><PathNode><x>1</x><y>0</y><width>-1</width></PathNode><PathNode><x>1489</x><y>-152</y><width>24</width></PathNode><PathNode><x>1496</x><y>-92</y><width>9</width></PathNode><PathNode><x>60</x><y>-3</y><width>2</width></PathNode></nodes></geometry></tcmV01></TrafficControlMessage>',
+        '[DEBUG 19:03:22.544 [TcmReqServlet] - <?xml version="1.0" encoding="UTF-8"?><TrafficControlRequest port="33333" list="true"><reqid>FDB705339E0F4C1B</reqid><reqseq>0</reqseq><scale>-1</scale><bounds><TrafficControlBounds><oldest>29107863</oldest><reflon>-771510186</reflon><reflat>389548654</reflat><offsets><OffsetPoint><deltax>3015</deltax><deltay>0</deltay></OffsetPoint><OffsetPoint><deltax>3015</deltax><deltay>1049</deltay></OffsetPoint><OffsetPoint><deltax>0</deltax><deltay>1049</deltay></OffsetPoint></offsets></TrafficControlBounds></bounds></TrafficControlRequest>',
+        '[DEBUG 19:03:22.547 [TcmReqServlet] - <?xml version="1.0" encoding="UTF-8"?><TrafficControlMessage><tcmV01><reqid>FDB705339E0F4C1B</reqid><reqseq>0</reqseq><msgtot>2</msgtot><msgnum>1</msgnum><id>008ba29f41eb4df1cf0a4e3a2ab11094</id><updated>0</updated><package><label>workzone</label><tcids><Id128b>008ba29f41eb4df1cf0a4e3a2ab11096</Id128b></tcids></package><params><vclasses><micromobile/><motorcycle/><passenger-car/><light-truck-van/><bus/><two-axle-six-tire-single-unit-truck/><three-axle-single-unit-truck/><four-or-more-axle-single-unit-truck/><four-or-fewer-axle-single-trailer-truck/><five-axle-single-trailer-truck/><six-or-more-axle-single-trailer-truck/><five-or-fewer-axle-multi-trailer-truck/><six-axle-multi-trailer-truck/><seven-or-more-axle-multi-trailer-truck/></vclasses><schedule><start>29109288</start><end>153722867280912</end><dow>1111111</dow></schedule><regulatory><true/></regulatory><detail><closed><notopen/></closed></detail></params><geometry><proj>epsg:3785</proj><datum>WGS84</datum><reftime>29109288</reftime><reflon>-771486221</reflon><reflat>389549122</reflat><refelv>0</refelv><heading>3312</heading><nodes><PathNode><x>5</x><y>0</y><width>1</width></PathNode><PathNode><x>-1491</x><y>94</y><width>8</width></PathNode><PathNode><x>-830</x><y>80</y><width>3</width></PathNode></nodes></geometry></tcmV01></TrafficControlMessage>',
+        '[DEBUG 19:03:22.548 [TcmReqServlet] - <?xml version="1.0" encoding="UTF-8"?><TrafficControlMessage><tcmV01><reqid>FDB705339E0F4C1B</reqid><reqseq>0</reqseq><msgtot>2</msgtot><msgnum>2</msgnum><id>00305feb9eac2d077bd5f534833d0152</id><updated>0</updated><package><label>workzone</label><tcids><Id128b>00305feb9eac2d077bd5f534833d0151</Id128b></tcids></package><params><vclasses><micromobile/><motorcycle/><passenger-car/><light-truck-van/><bus/><two-axle-six-tire-single-unit-truck/><three-axle-single-unit-truck/><four-or-more-axle-single-unit-truck/><four-or-fewer-axle-single-trailer-truck/><five-axle-single-trailer-truck/><six-or-more-axle-single-trailer-truck/><five-or-fewer-axle-multi-trailer-truck/><six-axle-multi-trailer-truck/><seven-or-more-axle-multi-trailer-truck/></vclasses><schedule><start>29129391</start><end>153722867280912</end><dow>1111111</dow></schedule><regulatory><true/></regulatory><detail><maxspeed>45</maxspeed></detail></params><geometry><proj>epsg:3785</proj><datum>WGS84</datum><reftime>29129391</reftime><reflon>-771488786</reflon><reflat>389548996</reflat><refelv>0</refelv><heading>3312</heading><nodes><PathNode><x>1</x><y>0</y><width>-1</width></PathNode><PathNode><x>1489</x><y>-152</y><width>24</width></PathNode><PathNode><x>1496</x><y>-92</y><width>9</width></PathNode><PathNode><x>60</x><y>-3</y><width>2</width></PathNode></nodes></geometry></tcmV01></TrafficControlMessage>',
+        '[DEBUG 19:03:25.601 [TcmReqServlet] - <?xml version="1.0" encoding="UTF-8"?><TrafficControlRequest port="33333" list="true"><reqid>F804AA710EA64E31</reqid><reqseq>0</reqseq><scale>-1</scale><bounds><TrafficControlBounds><oldest>29107863</oldest><reflon>-771510186</reflon><reflat>389548654</reflat><offsets><OffsetPoint><deltax>3015</deltax><deltay>0</deltay></OffsetPoint><OffsetPoint><deltax>3015</deltax><deltay>1049</deltay></OffsetPoint><OffsetPoint><deltax>0</deltax><deltay>1049</deltay></OffsetPoint></offsets></TrafficControlBounds></bounds></TrafficControlRequest>',
+        '[DEBUG 19:03:25.605 [TcmReqServlet] - <?xml version="1.0" encoding="UTF-8"?><TrafficControlMessage><tcmV01><reqid>F804AA710EA64E31</reqid><reqseq>0</reqseq><msgtot>2</msgtot><msgnum>1</msgnum><id>008ba29f41eb4df1cf0a4e3a2ab11095</id><updated>0</updated><package><label>workzone</label><tcids><Id128b>008ba29f41eb4df1cf0a4e3a2ab11096</Id128b></tcids></package><params><vclasses><micromobile/><motorcycle/><passenger-car/><light-truck-van/><bus/><two-axle-six-tire-single-unit-truck/><three-axle-single-unit-truck/><four-or-more-axle-single-unit-truck/><four-or-fewer-axle-single-trailer-truck/><five-axle-single-trailer-truck/><six-or-more-axle-single-trailer-truck/><five-or-fewer-axle-multi-trailer-truck/><six-axle-multi-trailer-truck/><seven-or-more-axle-multi-trailer-truck/></vclasses><schedule><start>29109288</start><end>153722867280912</end><dow>1111111</dow></schedule><regulatory><true/></regulatory><detail><closed><notopen/></closed></detail></params><geometry><proj>epsg:3785</proj><datum>WGS84</datum><reftime>29109288</reftime><reflon>-771486221</reflon><reflat>389549122</reflat><refelv>0</refelv><heading>3312</heading><nodes><PathNode><x>5</x><y>0</y><width>1</width></PathNode><PathNode><x>-1491</x><y>94</y><width>8</width></PathNode><PathNode><x>-830</x><y>80</y><width>3</width></PathNode></nodes></geometry></tcmV01></TrafficControlMessage>',
+        '[DEBUG 19:03:25.606 [TcmReqServlet] - <?xml version="1.0" encoding="UTF-8"?><TrafficControlMessage><tcmV01><reqid>F804AA710EA64E31</reqid><reqseq>0</reqseq><msgtot>2</msgtot><msgnum>2</msgnum><id>00305feb9eac2d077bd5f534833d0153</id><updated>0</updated><package><label>workzone</label><tcids><Id128b>00305feb9eac2d077bd5f534833d0151</Id128b></tcids></package><params><vclasses><micromobile/><motorcycle/><passenger-car/><light-truck-van/><bus/><two-axle-six-tire-single-unit-truck/><three-axle-single-unit-truck/><four-or-more-axle-single-unit-truck/><four-or-fewer-axle-single-trailer-truck/><five-axle-single-trailer-truck/><six-or-more-axle-single-trailer-truck/><five-or-fewer-axle-multi-trailer-truck/><six-axle-multi-trailer-truck/><seven-or-more-axle-multi-trailer-truck/></vclasses><schedule><start>29129391</start><end>153722867280912</end><dow>1111111</dow></schedule><regulatory><true/></regulatory><detail><maxspeed>45</maxspeed></detail></params><geometry><proj>epsg:3785</proj><datum>WGS84</datum><reftime>29129391</reftime><reflon>-771488786</reflon><reflat>389548996</reflat><refelv>0</refelv><heading>3312</heading><nodes><PathNode><x>1</x><y>0</y><width>-1</width></PathNode><PathNode><x>1489</x><y>-152</y><width>24</width></PathNode><PathNode><x>1496</x><y>-92</y><width>9</width></PathNode><PathNode><x>60</x><y>-3</y><width>2</width></PathNode></nodes></geometry></tcmV01></TrafficControlMessage>',
+        '[DEBUG 19:03:28.521 [TcmReqServlet] - <?xml version="1.0" encoding="UTF-8"?><TrafficControlRequest port="33333" list="true"><reqid>D3F3512874AC47A1</reqid><reqseq>0</reqseq><scale>-1</scale><bounds><TrafficControlBounds><oldest>29107863</oldest><reflon>-771510186</reflon><reflat>389548654</reflat><offsets><OffsetPoint><deltax>3015</deltax><deltay>0</deltay></OffsetPoint><OffsetPoint><deltax>3015</deltax><deltay>1049</deltay></OffsetPoint><OffsetPoint><deltax>0</deltax><deltay>1049</deltay></OffsetPoint></offsets></TrafficControlBounds></bounds></TrafficControlRequest>',
+        '[DEBUG 19:03:28.525 [TcmReqServlet] - <?xml version="1.0" encoding="UTF-8"?><TrafficControlMessage><tcmV01><reqid>D3F3512874AC47A1</reqid><reqseq>0</reqseq><msgtot>2</msgtot><msgnum>1</msgnum><id>008ba29f41eb4df1cf0a4e3a2ab11096</id><updated>0</updated><package><label>workzone</label><tcids><Id128b>008ba29f41eb4df1cf0a4e3a2ab11096</Id128b></tcids></package><params><vclasses><micromobile/><motorcycle/><passenger-car/><light-truck-van/><bus/><two-axle-six-tire-single-unit-truck/><three-axle-single-unit-truck/><four-or-more-axle-single-unit-truck/><four-or-fewer-axle-single-trailer-truck/><five-axle-single-trailer-truck/><six-or-more-axle-single-trailer-truck/><five-or-fewer-axle-multi-trailer-truck/><six-axle-multi-trailer-truck/><seven-or-more-axle-multi-trailer-truck/></vclasses><schedule><start>29109288</start><end>153722867280912</end><dow>1111111</dow></schedule><regulatory><true/></regulatory><detail><closed><notopen/></closed></detail></params><geometry><proj>epsg:3785</proj><datum>WGS84</datum><reftime>29109288</reftime><reflon>-771486221</reflon><reflat>389549122</reflat><refelv>0</refelv><heading>3312</heading><nodes><PathNode><x>5</x><y>0</y><width>1</width></PathNode><PathNode><x>-1491</x><y>94</y><width>8</width></PathNode><PathNode><x>-830</x><y>80</y><width>3</width></PathNode></nodes></geometry></tcmV01></TrafficControlMessage>',
+        '[DEBUG 19:03:28.526 [TcmReqServlet] - <?xml version="1.0" encoding="UTF-8"?><TrafficControlMessage><tcmV01><reqid>D3F3512874AC47A1</reqid><reqseq>0</reqseq><msgtot>2</msgtot><msgnum>2</msgnum><id>00305feb9eac2d077bd5f534833d0151</id><updated>0</updated><package><label>workzone</label><tcids><Id128b>00305feb9eac2d077bd5f534833d0151</Id128b></tcids></package><params><vclasses><micromobile/><motorcycle/><passenger-car/><light-truck-van/><bus/><two-axle-six-tire-single-unit-truck/><three-axle-single-unit-truck/><four-or-more-axle-single-unit-truck/><four-or-fewer-axle-single-trailer-truck/><five-axle-single-trailer-truck/><six-or-more-axle-single-trailer-truck/><five-or-fewer-axle-multi-trailer-truck/><six-axle-multi-trailer-truck/><seven-or-more-axle-multi-trailer-truck/></vclasses><schedule><start>29129391</start><end>153722867280912</end><dow>1111111</dow></schedule><regulatory><true/></regulatory><detail><maxspeed>45</maxspeed></detail></params><geometry><proj>epsg:3785</proj><datum>WGS84</datum><reftime>29129391</reftime><reflon>-771488786</reflon><reflat>389548996</reflat><refelv>0</refelv><heading>3312</heading><nodes><PathNode><x>1</x><y>0</y><width>-1</width></PathNode><PathNode><x>1489</x><y>-152</y><width>24</width></PathNode><PathNode><x>1496</x><y>-92</y><width>9</width></PathNode><PathNode><x>60</x><y>-3</y><width>2</width></PathNode></nodes></geometry></tcmV01></TrafficControlMessage>'
+    
+    ]
+
+    file_contents = "\n".join(sample_lines)+"\n"
+
+    with patch('os.listdir', return_value=fake_files), \
+        patch('os.path.isfile', return_value=True), \
+        patch('builtins.open', mock_open(read_data=file_contents)) as mock_file, \
+        patch('message_scripts.plt') as mock_plt, \
+        patch.object(Path, "mkdir") as mock_mkdir, \
+        patch("numpy.savez") as mock_savez, \
+        patch("json.dump") as mock_json_dump:
+
+        mock_fig = MagicMock()
+        mock_ax1 = MagicMock()
+        mock_ax2 = MagicMock()
+        mock_plt.subplots.return_value = (mock_fig, (mock_ax1, mock_ax2))
+
+        with np.errstate(invalid='ignore'): # Purposefully ignoring error state on this, the sample cc logs will cause a float('inf') value for the rate which causes warning on calculating error statistics
+            all_results, _ = process_cc_logs_for_tcr_tcm_data(fake_save_dir, log_date, max_delay_sec, expected_rate_hz, fake_save_dir, fake_save_dir, None)
+
+        for reqid in expected_reqids:
+            assert reqid in all_results
+
+        for reqid, data in all_results.items():
+            assert isinstance(data, dict)
+
+            for key in ["first_tcm_time", "response_delay", "tcr_time"]:
+                assert key in data
+
+            for tcm_id, tcm_data in data.items():
+                if tcm_id in ["first_tcm_time", "response_delay", "tcr_time"]:
+                    continue
+                assert isinstance(tcm_data, dict)
+
+                for field in ["count", "msgnum", "rate", "timestamps"]:
+                    assert field in tcm_data
+
+                assert tcm_data["rate"] == approx(expected_rate_hz, rel=0.05)
+
+
+def test_passing_check_cc_response_delay():
+    fake_save_dir = '/fake/dir'
+    expected_delay_sec = 1
+
+    cc_data = {'A': {'tcr_time': 1, 'first_tcm_time': 1.1, 'response_delay': 0.1, 'a1': {'timestamps': [1.1, 1.3, 1.5], 'msgnum': 1, 'count': 3, 'rate': 5}},
+               'B': {'tcr_time': 1.5, 'first_Tcm_time': 2.4, 'response_delay': 0.9, 'b1': {'timestamps': [2.4], 'msgnum': 1, 'count': 1, 'rate': 0}}
+    }
+
+    with patch.object(Path, "mkdir") as mock_mkdir, \
+        patch("numpy.savez") as mock_savez, \
+        patch("builtins.open", mock_open()) as mock_file, \
+        patch("json.dump") as mock_json_dump:
+    
+        passed = check_cc_response_delay(cc_data, expected_delay_sec, fake_save_dir, fake_save_dir)
+
+        assert passed
+
+
+def test_failing_check_cc_response_delay():
+    fake_save_dir = '/fake/dir'
+    expected_delay_sec = 1
+
+    cc_data = {'A': {'tcr_time': 1, 'first_tcm_time': 1.1, 'response_delay': 0.1, 'a1': {'timestamps': [1.1, 1.3, 1.5], 'msgnum': 1, 'count': 3, 'rate': 5}},
+               'B': {'tcr_time': 1.5, 'first_Tcm_time': 2.6, 'response_delay': 1.1, 'b1': {'timestamps': [2.6], 'msgnum': 1, 'count': 1, 'rate': 0}}
+    }
+
+    with patch.object(Path, "mkdir") as mock_mkdir, \
+        patch("numpy.savez") as mock_savez, \
+        patch("builtins.open", mock_open()) as mock_file, \
+        patch("json.dump") as mock_json_dump:
+    
+        passed = check_cc_response_delay(cc_data, expected_delay_sec, fake_save_dir, fake_save_dir)
+
+        assert not passed
+
+
+def test_passing_check_tcm_broadcast_count():
+    fake_save_dir = '/fake/dir'
+    expected_count = 3
+
+    cc_data = {'A': {'tcr_time': 1, 'first_tcm_time': 1.1, 'response_delay': 0.1, 'a1': {'timestamps': [1.1, 1.3, 1.5], 'msgnum': 1, 'count': 3, 'rate': 5}},
+               'B': {'tcr_time': 1.5, 'first_tcm_time': 2.6, 'response_delay': 1.1, 'b1': {'timestamps': [2.6], 'msgnum': 2, 'count': 1, 'rate': 0}}
+    }
+
+    acknowledgements = [('A', 1, 1.1, 1.2), ('B', 2, 2.6, 3.2)]
+
+    with patch.object(Path, "mkdir") as mock_mkdir, \
+        patch("numpy.savez") as mock_savez, \
+        patch("builtins.open", mock_open()) as mock_file, \
+        patch("json.dump") as mock_json_dump:
+
+        passed = check_tcm_broadcast_count(cc_data, acknowledgements, expected_count, fake_save_dir, fake_save_dir)
+
+        assert passed
+
+
+def test_failing_check_tcm_broadcast_count():
+    fake_save_dir = '/fake/dir'
+    expected_count = 2 # Causes failure on 'A' because the count is greater than expected
+
+    cc_data = {'A': {'tcr_time': 1, 'first_tcm_time': 1.1, 'response_delay': 0.1, 'a1': {'timestamps': [1.1, 1.3, 1.5], 'msgnum': 1, 'count': 3, 'rate': 5}},
+               'B': {'tcr_time': 1.5, 'first_tcm_time': 2.6, 'response_delay': 1.1, 'b1': {'timestamps': [2.6], 'msgnum': 2, 'count': 1, 'rate': 0}}
+    }
+
+    acknowledgements = [('A', 1, 1.1, 1.2)] # Causes failure on 'B' because count is less than expected AND was not acknowledged
+
+    with patch.object(Path, "mkdir") as mock_mkdir, \
+        patch("numpy.savez") as mock_savez, \
+        patch("builtins.open", mock_open()) as mock_file, \
+        patch("json.dump") as mock_json_dump:
+
+        passed = check_tcm_broadcast_count(cc_data, acknowledgements, expected_count, fake_save_dir, fake_save_dir)
+
+        assert not passed
+
+
+def test_passing_check_tcm_broadcast_rate():
+    fake_save_dir = '/fake/dir'
+    expected_rate_hz = 5
+
+    cc_data = {'A': {'tcr_time': 1, 'first_tcm_time': 1.1, 'response_delay': 0.1, 'a1': {'timestamps': [1.1, 1.3, 1.5], 'msgnum': 1, 'count': 3, 'rate': 5}},
+               'B': {'tcr_time': 1.5, 'first_tcm_time': 2.6, 'response_delay': 1.1, 'b1': {'timestamps': [2.6], 'msgnum': 2, 'count': 1, 'rate': 0}}
+    }
+
+    acknowledgements = [('A', 1, 1.1, 1.2), ('B', 2, 2.6, 3.2)]
+
+    with patch.object(Path, "mkdir") as mock_mkdir, \
+        patch("numpy.savez") as mock_savez, \
+        patch("builtins.open", mock_open()) as mock_file, \
+        patch("json.dump") as mock_json_dump:
+
+        passed = check_tcm_broadcast_rate(cc_data, acknowledgements, expected_rate_hz, fake_save_dir, fake_save_dir)
+
+        assert passed
+
+
+def test_failing_check_tcm_broadcast_rate():
+    fake_save_dir = '/fake/dir'
+    expected_rate_hz = 10 # Fails 'A' for having an incorrect rate (still accepted because acknowledged)
+
+    cc_data = {'A': {'tcr_time': 1, 'first_tcm_time': 1.1, 'response_delay': 0.1, 'a1': {'timestamps': [1.1, 1.3, 1.5], 'msgnum': 1, 'count': 3, 'rate': 5}},
+               'B': {'tcr_time': 1.5, 'first_tcm_time': 2.6, 'response_delay': 1.1, 'b1': {'timestamps': [2.6], 'msgnum': 2, 'count': 1, 'rate': 0}}
+    }
+
+    acknowledgements = [('A', 1, 1.1, 1.2)] # Fails 'B' because rate is wrong AND not acknowledged
+
+    with patch.object(Path, "mkdir") as mock_mkdir, \
+        patch("numpy.savez") as mock_savez, \
+        patch("builtins.open", mock_open()) as mock_file, \
+        patch("json.dump") as mock_json_dump:
+
+        passed = check_tcm_broadcast_rate(cc_data, acknowledgements, expected_rate_hz, fake_save_dir, fake_save_dir)
+
+        assert not passed
+


### PR DESCRIPTION
# PR Details
## Description

Created unit tests for the following functions to increase sonar code coverage of src/carma-platform/guidance_scripts.py and src/carma_platform/message_scripts.py:

- guidance_scripts.get_lateral_velocities
- guidance_scripts.check_reroute_duration
- guidance_scripts.check_speed_limits_in_geofence
- guidance_scripts.check_geofence_in_reroute
- guidance_scripts.get_route_original_speed
- guidance_scripts.get_geofence_entrance_and_exit_times
- message_scripts.process_cc_logs_for_tcr_tcm_data
- message_scripts.check_cc_response_delay
- message_scripts.check_tcm_acknowledgement_delay
- message_scripts.check_tcm_broadcast_count
- message_scripts.check_tcm_broadcast_rate
- message_scripts.check_tcm_response_time

## Related GitHub Issue

## Related Jira Key

ARC-405

## Motivation and Context

Workzone data analytics scripts were pushed previously to release/stingray without unit tests written, causing sonar code coverage scans to drop below the required threshold.

## How Has This Been Tested?

Testing occurred on dev container in Visual Studio Code using carma-platform:develop docker image
Pytest was used to run unit tests
pytest-cov was used to generate coverage against a file, and create an html report for coverage visualization

Coverage for individual functions was tested using:
"python3 -m pytest --cov=<guidance_scripts|message_scripts> --cov-report=html test-<guidance|message>-scripts.py::<unit test being run>
from src/carma-platform/test directory

Total file coverage was tested using:
"python3 -m pytest --cov=message_scripts --cov=guidance_scripts --cov-report=html test"
from src/carma-platform directory

Coverage before changes:
![image](https://github.com/user-attachments/assets/671fdbd2-3c9e-4e47-a895-603efb517670)

Coverage after changes:
![image](https://github.com/user-attachments/assets/b61c0390-9af7-441a-b353-6102a5741d7c)

NOTE:
- message_scripts.py had no unit tests prior so starting code coverage was 0%
- sonar scan code coverage requires 80%, the coverage report after changes for both message_scripts.py and guidance_scripts.py are still below 80%. The remaining functions are being handled in ARC-406

## Types of changes

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
